### PR TITLE
Check length of the serviceList before indexing

### DIFF
--- a/pkg/database/funcs.go
+++ b/pkg/database/funcs.go
@@ -66,7 +66,7 @@ func (d *Database) setDatabaseHostname(
 		h.GetBeforeObject().GetNamespace(),
 		selector,
 	)
-	if err != nil {
+	if err != nil || len(serviceList.Items) == 0 {
 		msg := fmt.Sprintf("Error getting the DB service using label %v", selector)
 		cond := condition.NewCondition(
 			condition.TypeError,


### PR DESCRIPTION
Database.setDatabaseHostname() call assumed that
common.GetServicesListWithLabel returns an error if no service is found.
However that call returns an empty list instead. This could lead to
panic in setDatabaseHostname when tried to index an empty list.

This patch extend the error guard condition to cover the empty list
case.

Closes openstack-k8s-operators#27