### PR TITLE
Don't return an error if resource is not found in keystone

### DIFF
--- a/pkg/openstack/role.go
+++ b/pkg/openstack/role.go
@@ -80,7 +80,8 @@ func (o *OpenStack) GetRole(
 	}
 
 	if len(allRoles) == 0 {
-		return nil, fmt.Errorf(fmt.Sprintf("%s role not found in keystone", roleName))
+		log.Info(fmt.Sprintf("%s role not found in keystone", roleName))
+		return nil, nil
 	}
 
 	return &allRoles[0], nil

--- a/pkg/openstack/service.go
+++ b/pkg/openstack/service.go
@@ -81,7 +81,8 @@ func (o *OpenStack) GetService(
 	}
 
 	if len(allServices) == 0 {
-		return nil, fmt.Errorf(fmt.Sprintf("%s service not found in keystone", serviceName))
+		log.Info(fmt.Sprintf("%s service not found in keystone", serviceName))
+		return nil, nil
 	}
 
 	return &allServices[0], nil

--- a/pkg/openstack/user.go
+++ b/pkg/openstack/user.go
@@ -86,7 +86,9 @@ func (o *OpenStack) GetUser(
 	}
 
 	if len(allUsers) == 0 {
-		return nil, fmt.Errorf(fmt.Sprintf("%s user not found in keystone", userName))
+		log.Info(fmt.Sprintf("%s user not found in keystone", userName))
+
+		return nil, nil
 	}
 
 	return &allUsers[0], nil


### PR DESCRIPTION
GetUser, GetService and GetRole returned an error if the
specified resource with the name could not be found, which
is still ok when checked if it exists or need to be created.
In that case return nil and the caller need to check on that
and acts appropriate.