### PR TITLE
Exit when go checks detect error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ testbin
 manager
 go.work
 go.work.sum
+modules/*/vendor/
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -73,31 +73,31 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 # Run go fmt against code
 gofmt: get-ci-tools
 	for mod in $(shell find modules/ -maxdepth 1 -mindepth 1 -type d); do \
-		GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/gofmt.sh ./$$mod ; \
+		GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/gofmt.sh ./$$mod || exit 1 ; \
 	done
 
 # Run go vet against code
 govet: get-ci-tools
 	for mod in $(shell find modules/ -maxdepth 1 -mindepth 1 -type d); do \
-		GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/govet.sh ./$$mod ; \
+		GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/govet.sh ./$$mod || exit 1 ; \
 	done
 
 # Run go test against code
 gotest: get-ci-tools
 	for mod in $(shell find modules/ -maxdepth 1 -mindepth 1 -type d); do \
-		GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/gotest.sh ./$$mod ; \
+		GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/gotest.sh ./$$mod || exit 1 ; \
 	done
 
 # Run golangci-lint test against code
 golangci: get-ci-tools
 	for mod in $(shell find modules/ -maxdepth 1 -mindepth 1 -type d); do \
-		GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/golangci.sh ./$$mod ; \
+		GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/golangci.sh ./$$mod || exit 1 ; \
 	done
 
 # Run go lint against code
 golint: get-ci-tools
 	for mod in $(shell find modules/ -maxdepth 1 -mindepth 1 -type d); do \
-		PATH=$(GOBIN):$(PATH); GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/golint.sh $$mod ; \
+		PATH=$(GOBIN):$(PATH); GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/golint.sh $$mod || exit 1; \
 	done
 
 gowork:

--- a/modules/common/endpoint/endpoint.go
+++ b/modules/common/endpoint/endpoint.go
@@ -41,8 +41,8 @@ const (
 	EndpointPublic Endpoint = "public"
 )
 
-// EndpointData - information for generation of K8S services and Keystone endpoint URLs
-type EndpointData struct {
+// Data - information for generation of K8S services and Keystone endpoint URLs
+type Data struct {
 	// Used in k8s service definition
 	Port int32
 	// An optional path suffix to append to route hostname when forming Keystone endpoint URLs
@@ -57,7 +57,7 @@ func ExposeEndpoints(
 	h *helper.Helper,
 	serviceName string,
 	endpointSelector map[string]string,
-	endpoints map[Endpoint]EndpointData,
+	endpoints map[Endpoint]Data,
 ) (map[string]string, ctrl.Result, error) {
 	endpointMap := make(map[string]string)
 


### PR DESCRIPTION
* ignore vendor dirs if created in modules folders
* Exit if there is an error found in check runs looping over folders
* Fix EndpointData lint error