### PR TITLE
Add Mirror functionality to sync lower level object condition state into the upper level

### DIFF
--- a/modules/common/condition/types.go
+++ b/modules/common/condition/types.go
@@ -77,3 +77,10 @@ type Condition struct {
 
 // Conditions provide observations of the operational state of a API resource.
 type Conditions []Condition
+
+// conditionGroup defines a group of conditions with the same status and severity,
+type conditionGroup struct {
+	status     corev1.ConditionStatus
+	severity   Severity
+	conditions Conditions
+}


### PR DESCRIPTION
*   Add Mirror(t Type) to reflect client object conditions state
    
    Mirror(t) mirrors Status, Message, Reason and Severity from the
    latest condition of a sorted conditionGroup list into a target
    condition of type t.
    The conditionGroup entries are split by Status with the order
    False, True, Unknown. If Status=False its again split into Severity
    with the order Error, Warning, Info.
    
    If the overall ReadyConditon is true, it is expected that this is
    the actual state and no other groups need to be checked.
    
    To e.g. mirror the keystoneservice object condition it only required
    to use:
    ~~~
    c := ksSvc.GetConditions().Mirror(condition.KeystoneServiceReadyCondition)
    if c != nil {
      instance.Status.Conditions.Set(c)
    }
    ~~~
    
    Example Depends-On: https://github.com/openstack-k8s-operators/keystone-operator/pull/84
