### PR TITLE
Prevent segfault when DB instance is not found

### DIFF
--- a/modules/database/funcs.go
+++ b/modules/database/funcs.go
@@ -66,11 +66,8 @@ func (d *Database) setDatabaseHostname(
 		selector,
 	)
 	if err != nil || len(serviceList.Items) == 0 {
-		return util.WrapErrorForObject(
-			fmt.Sprintf("Error getting the DB service using label %v", selector),
-			d.database,
-			err,
-		)
+		return fmt.Errorf("Error getting the DB service using label %v: %w",
+			selector, err)
 	}
 
 	// can we expect there is only one DB instance per namespace?


### PR DESCRIPTION
When trying to deploy Keystone without MariaDB being already deployed,
the Keystone operator would segfault as follows [1]. The segfault is
now fixed by not trying to dereference the d.database pointer when the
database wasn't found.

[1]
```
1.6606757169899645e+09  INFO    controllers.KeystoneAPI Reconciling Service
1.6606757170078285e+09  INFO    controllers.KeystoneAPI Input maps hash input - n58bh5f6h59ch599hf5hfchc5h558h9chdh598h66bh8hch669h5h595hf5h676h5f7h85h545hfch66bh655h67h569h556h56hdbh699h546q
1.660675717007914e+09   INFO    controllers.KeystoneAPI Reconciling Service init
1.6606757170226123e+09  INFO    Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference        {"controller": "keystoneapi", "controllerGroup": "keystone.openstack.org", "controllerKind": "KeystoneAPI", "keystoneAPI": {"name":"keystone","namespace":"openstack"}, "namespace": "openstack", "name": "keystone", "reconcileID": "6828bfe1-a1c8-40d8-847d-63c31806ebb3"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1516cc0]

goroutine 474 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:118 +0x1f4
panic({0x16fdd80, 0x27361b0})
        /usr/local/go/src/runtime/panic.go:838 +0x207
github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1.(*MariaDBDatabase).GetNamespace(0x7fca8d5b5108?)
        <autogenerated>:1
sigs.k8s.io/controller-runtime/pkg/client.ObjectKeyFromObject({0x1b82608, 0x0})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/client/interfaces.go:35 +0x27
github.com/openstack-k8s-operators/lib-common/modules/common/util.WrapErrorForObject({0xc0038a9400, 0x39}, {0x1b82608?, 0x0}, {0x0?, 0x0})
        /go/pkg/mod/github.com/openstack-k8s-operators/lib-common/modules/common@v0.0.0-20220816094529-135dc67c2cdf/util/log.go:49 +0x6b
github.com/openstack-k8s-operators/lib-common/modules/database.(*Database).setDatabaseHostname(0xc0039a2970, {0x1b74308, 0xc00388d200}, 0xc0001d54a0)
        /go/pkg/mod/github.com/openstack-k8s-operators/lib-common/modules/database@v0.0.0-20220816094529-135dc67c2cdf/funcs.go:69 +0x131
github.com/openstack-k8s-operators/lib-common/modules/database.(*Database).CreateOrPatchDB(0xc0039a2970, {0x1b74308, 0xc00388d200}, 0xc0001d54a0)
        /go/pkg/mod/github.com/openstack-k8s-operators/lib-common/modules/database@v0.0.0-20220816094529-135dc67c2cdf/funcs.go:123 +0x145
github.com/openstack-k8s-operators/keystone-operator/controllers.(*KeystoneAPIReconciler).reconcileInit(0xc00062ae80, {0x1b74308, 0xc00388d200}, 0xc00388e6c0, 0xa?, 0x0?)
        /remote-source/controllers/keystoneapi_controller.go:228 +0x1b8
github.com/openstack-k8s-operators/keystone-operator/controllers.(*KeystoneAPIReconciler).reconcileNormal(0xc00062ae80, {0x1b74308, 0xc00388d200}, 0xc00388e6c0, 0xc0001d54a0)
        /remote-source/controllers/keystoneapi_controller.go:535 +0x6c8
github.com/openstack-k8s-operators/keystone-operator/controllers.(*KeystoneAPIReconciler).Reconcile(0xc00062ae80, {0x1b74308, 0xc00388d200}, {{{0xc000718e80, 0x9}, {0xc000718e70, 0x8}}})
        /remote-source/controllers/keystoneapi_controller.go:178 +0x9d0
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x1b74260?, {0x1b74308?, 0xc00388d200?}, {{{0xc000718e80?, 0x184e540?}, {0xc000718e70?, 0x4041f4?}}})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:121 +0xc8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0002aeb40, {0x1b74260, 0xc00054bb00}, {0x176f240?, 0xc0005945a0?})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:320 +0x33c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0002aeb40, {0x1b74260, 0xc00054bb00})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:273 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:234 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:230 +0x325
```