### PR TITLE
Allow the Service Type and ExternalIPs to be set

### DIFF
--- a/modules/common/service/service.go
+++ b/modules/common/service/service.go
@@ -55,6 +55,7 @@ func GenericService(svcInfo *GenericServiceDetails) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: svcInfo.Selector,
+			Type: svcInfo.Type,
 			Ports: []corev1.ServicePort{
 				{
 					Name: svcInfo.Port.Name,
@@ -64,6 +65,7 @@ func GenericService(svcInfo *GenericServiceDetails) *corev1.Service {
 					Protocol: svcInfo.Port.Protocol,
 				},
 			},
+			ExternalIPs: svcInfo.ExternalIPs,
 		},
 	}
 }

--- a/modules/common/service/types.go
+++ b/modules/common/service/types.go
@@ -26,11 +26,13 @@ type Service struct {
 
 // GenericServiceDetails -
 type GenericServiceDetails struct {
-	Name      string
-	Namespace string
-	Labels    map[string]string
-	Selector  map[string]string
-	Port      GenericServicePort
+	Name        string
+	Namespace   string
+	Labels      map[string]string
+	Selector    map[string]string
+	Port        GenericServicePort
+	Type        corev1.ServiceType
+	ExternalIPs []string
 }
 
 // GenericServicePort -


### PR DESCRIPTION
This accomodates Services which need to be a type other than ClusterIP (such as NodePort, etc).