### PR TITLE
Fix hashing of ConfigMaps

### DIFF
--- a/modules/common/configmap/configmap.go
+++ b/modules/common/configmap/configmap.go
@@ -34,6 +34,27 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 )
 
+
+
+// Hash function creates a hash of a ConfigMap's Data and BinaryData fields and
+// returns it as a safe encoded string.
+func Hash(configMap *corev1.ConfigMap) (string, error) {
+	type ConfigMapData struct {
+		Data map[string]string `json:"data,omitempty" protobuf:"bytes,2,rep,name=data"`
+		BinaryData map[string][]byte `json:"binaryData,omitempty" protobuf:"bytes,3,rep,name=binaryData"`
+	}
+
+	if configMap == nil {
+		return "", fmt.Errorf("nil ConfigMap doesn't have data to hash")
+	}
+
+	data := ConfigMapData{
+		Data: configMap.Data,
+		BinaryData: configMap.BinaryData,
+	}
+	return util.ObjectHash(data)
+}
+
 // createOrPatchConfigMap -
 func createOrPatchConfigMap(
 	ctx context.Context,
@@ -83,7 +104,7 @@ func createOrPatchConfigMap(
 		return "", op, fmt.Errorf("error create/updating configmap: %v", err)
 	}
 
-	configMapHash, err := util.ObjectHash(configMap)
+	configMapHash, err := Hash(configMap)
 	if err != nil {
 		return "", op, fmt.Errorf("error calculating configuration hash: %v", err)
 	}
@@ -128,7 +149,7 @@ func createOrGetCustomConfigMap(
 		configMap.Data = foundConfigMap.Data
 	}
 
-	configMapHash, err := util.ObjectHash(configMap)
+	configMapHash, err := Hash(configMap)
 	if err != nil {
 		return "", fmt.Errorf("error calculating configuration hash: %v", err)
 	}
@@ -209,7 +230,7 @@ func GetConfigMapAndHashWithName(
 		h.GetLogger().Error(err, configMapName+" ConfigMap not found!", "Instance.Namespace", namespace, "ConfigMap.Name", configMapName)
 		return configMap, "", err
 	}
-	configMapHash, err := util.ObjectHash(configMap)
+	configMapHash, err := Hash(configMap)
 	if err != nil {
 		return configMap, "", fmt.Errorf("error calculating configuration hash: %v", err)
 	}


### PR DESCRIPTION
Whenever an operator creates a new `ConfigMap` using methods `createOrPatchConfigMap` or `createOrGetCustomConfigMap` the calculated has will not be correct.

Due to this incorrect hash we end up seeing 1 unnecessary destroy/create cycle of the pods.

In the Cinder where this was observed we would see that at least the cinder-volume, cinder-backup, and cinder-scheduler containers would successfully run their init containers and then the services would start running displaying their logs, but a couple of seconds later they would just be terminated just to do the cycle again.

After 1 terminate/create cycle they would stabilize.

We could see that their respective `StatefulSet` had a `generation` count of 2 (when it should be 1) and this was caused by a change of the `ConfigMap` hash.

The problem comes from a difference in the hash calculation of a newly created `ConfigMap` and the same one when retrieved from OpenShift.

This happens because when we create the `ConfigMap` it will locally set the `TypeMeta` fields to empty strings (even if we set it otherwise), but when we get the `ConfigMap` from OpenShift it will have `Kind` and `APIVersion` set.

This patch solves the issue by only hashing the actual data from the `ConfigMap`, fields `Data` and `BinaryData` instead of the whole `ConfigMap`.
