### PR TITLE
Improvements to openstack module

### DIFF
--- a/modules/common/condition/conditions.go
+++ b/modules/common/condition/conditions.go
@@ -48,6 +48,9 @@ const (
 
 	// KeystoneServiceReadyCondition This condition is mirrored from the Ready condition in the keystoneservice ref object to the service API.
 	KeystoneServiceReadyCondition Type = "KeystoneServiceReady"
+
+	// KeystoneEndpointReadyCondition This condition is mirrored from the Ready condition in the keystoneendpoint ref object to the service API.
+	KeystoneEndpointReadyCondition Type = "KeystoneEndpointReady"
 )
 
 //
@@ -89,10 +92,10 @@ const (
 	// Overall Ready Condition messages
 	//
 	// ReadyInitMessage
-	ReadyInitMessage = "Service setup started"
+	ReadyInitMessage = "Setup started"
 
 	// ReadyMessage
-	ReadyMessage = "Service setup complete"
+	ReadyMessage = "Setup complete"
 
 	//
 	// InputReady condition messages

--- a/modules/openstack/role.go
+++ b/modules/openstack/role.go
@@ -18,10 +18,14 @@ package openstack
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	roles "github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
 )
+
+// RoleNotFound - role not found error message"
+const RoleNotFound = "role not found in keystone"
 
 // Role -
 type Role struct {
@@ -41,7 +45,7 @@ func (o *OpenStack) CreateRole(
 		log,
 		roleName,
 	)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), RoleNotFound) {
 		return roleID, err
 	}
 
@@ -80,7 +84,7 @@ func (o *OpenStack) GetRole(
 	}
 
 	if len(allRoles) == 0 {
-		return nil, fmt.Errorf(fmt.Sprintf("%s role not found in keystone", roleName))
+		return nil, fmt.Errorf(fmt.Sprintf("%s %s", roleName, RoleNotFound))
 	}
 
 	return &allRoles[0], nil

--- a/modules/openstack/service.go
+++ b/modules/openstack/service.go
@@ -24,6 +24,9 @@ import (
 	services "github.com/gophercloud/gophercloud/openstack/identity/v3/services"
 )
 
+// ServiceNotFound - service not found error message"
+const ServiceNotFound = "service not found in keystone"
+
 // Service -
 type Service struct {
 	Name        string
@@ -46,7 +49,7 @@ func (o *OpenStack) CreateService(
 		s.Type,
 		s.Name,
 	)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), ServiceNotFound) {
 		return serviceID, err
 	}
 
@@ -97,7 +100,7 @@ func (o *OpenStack) GetService(
 	}
 
 	if len(allServices) == 0 {
-		return nil, fmt.Errorf(fmt.Sprintf("%s service not found in keystone", serviceName))
+		return nil, fmt.Errorf(fmt.Sprintf("%s %s", serviceName, ServiceNotFound))
 	}
 
 	return &allServices[0], nil

--- a/modules/openstack/user.go
+++ b/modules/openstack/user.go
@@ -24,6 +24,9 @@ import (
 	users "github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 )
 
+// UserNotFound - user not found error message"
+const UserNotFound = "user not found in keystone"
+
 // User -
 type User struct {
 	Name      string
@@ -45,7 +48,7 @@ func (o *OpenStack) CreateUser(
 		u.Name,
 	)
 	// If the user is not found, don't count that as an error here
-	if err != nil && !strings.Contains(err.Error(), "user not found in keystone") {
+	if err != nil && !strings.Contains(err.Error(), UserNotFound) {
 		return userID, err
 	}
 
@@ -88,7 +91,7 @@ func (o *OpenStack) GetUser(
 	}
 
 	if len(allUsers) == 0 {
-		return nil, fmt.Errorf(fmt.Sprintf("%s user not found in keystone", userName))
+		return nil, fmt.Errorf(fmt.Sprintf("%s %s", userName, UserNotFound))
 	}
 
 	return &allUsers[0], nil


### PR DESCRIPTION
* Introduce <Type>NotFound error const
    Adds ServiceNotFound, RoleNotFound and UserNotFound const, which allows to check for the specific error message and prevents hard coding specific error messages in different places.

* Validate in AssignUserRole() if the user is already part of role
    Before assigning the user to a role, check if it is already part of it. In this case no update to the role assignment is required.

* Check service is already present in CreateService()
    When the service with Name and Type is already present in keystone there is no need to create it. In this case just use it.

Also adds a new condition `KeystoneEndpointReadyCondition` and rewords the `ReadyInitMessage` and `ReadyMessage` to be more generic as it is not always a service which gets configured.
