### PR TITLE
Use Database.databaseName consistently to fix issue #65 

### DIFF
--- a/modules/database/funcs.go
+++ b/modules/database/funcs.go
@@ -250,28 +250,32 @@ func (d *Database) getDBWithName(
 	h *helper.Helper,
 ) error {
 	db := &mariadbv1.MariaDBDatabase{}
+	name := d.name
 	namespace := d.namespace
+	if name == "" {
+		name = h.GetBeforeObject().GetName()
+	}
 	if namespace == "" {
 		namespace = h.GetBeforeObject().GetNamespace()
 	}
 	err := h.GetClient().Get(
 		ctx,
 		types.NamespacedName{
-			Name:      d.databaseName,
+			Name:      name,
 			Namespace: namespace,
 		},
 		db)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			return util.WrapErrorForObject(
-				fmt.Sprintf("Failed to get %s database %s ", d.databaseName, namespace),
+				fmt.Sprintf("Failed to get %s database %s ", name, namespace),
 				h.GetBeforeObject(),
 				err,
 			)
 		}
 
 		return util.WrapErrorForObject(
-			fmt.Sprintf("DB error %s %s ", d.databaseName, namespace),
+			fmt.Sprintf("DB error %s %s ", name, namespace),
 			h.GetBeforeObject(),
 			err,
 		)

--- a/modules/database/funcs.go
+++ b/modules/database/funcs.go
@@ -45,6 +45,27 @@ func NewDatabase(
 		databaseUser: databaseUser,
 		secret:       secret,
 		labels:       labels,
+		name:         "",
+		namespace:    "",
+	}
+}
+
+// NewDatabaseWithNamespace returns an initialized DB.
+func NewDatabaseWithNamespace(
+	databaseName string,
+	databaseUser string,
+	secret string,
+	labels map[string]string,
+	name string,
+	namespace string,
+) *Database {
+	return &Database{
+		databaseName: databaseName,
+		databaseUser: databaseUser,
+		secret:       secret,
+		labels:       labels,
+		name:         name,
+		namespace:    namespace,
 	}
 }
 
@@ -122,15 +143,25 @@ func (d *Database) CreateOrPatchDBWithLabel(
 	labels map[string]string,
 ) (ctrl.Result, error) {
 
-	db := &mariadbv1.MariaDBDatabase{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      h.GetBeforeObject().GetName(),
-			Namespace: h.GetBeforeObject().GetNamespace(),
-		},
-		Spec: mariadbv1.MariaDBDatabaseSpec{
-			// the DB name must not change, therefore specify it outside the mutuate function
-			Name: d.databaseName,
-		},
+	if d.name == "" {
+		d.name = h.GetBeforeObject().GetName()
+	}
+	if d.namespace == "" {
+		d.namespace = h.GetBeforeObject().GetNamespace()
+	}
+
+	db := d.database
+	if db == nil {
+		db = &mariadbv1.MariaDBDatabase{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      d.name,
+				Namespace: d.namespace,
+			},
+			Spec: mariadbv1.MariaDBDatabaseSpec{
+				// the DB name must not change, therefore specify it outside the mutuate function
+				Name: d.databaseName,
+			},
+		}
 	}
 
 	// set the database hostname on the db instance
@@ -219,24 +250,28 @@ func (d *Database) getDBWithName(
 	h *helper.Helper,
 ) error {
 	db := &mariadbv1.MariaDBDatabase{}
+	namespace := d.namespace
+	if namespace == "" {
+		namespace = h.GetBeforeObject().GetNamespace()
+	}
 	err := h.GetClient().Get(
 		ctx,
 		types.NamespacedName{
 			Name:      d.databaseName,
-			Namespace: h.GetBeforeObject().GetNamespace(),
+			Namespace: namespace,
 		},
 		db)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			return util.WrapErrorForObject(
-				fmt.Sprintf("Failed to get %s database %s ", d.databaseName, h.GetBeforeObject().GetNamespace()),
+				fmt.Sprintf("Failed to get %s database %s ", d.databaseName, namespace),
 				h.GetBeforeObject(),
 				err,
 			)
 		}
 
 		return util.WrapErrorForObject(
-			fmt.Sprintf("DB error %s %s ", d.databaseName, h.GetBeforeObject().GetNamespace()),
+			fmt.Sprintf("DB error %s %s ", d.databaseName, namespace),
 			h.GetBeforeObject(),
 			err,
 		)

--- a/modules/database/types.go
+++ b/modules/database/types.go
@@ -33,4 +33,6 @@ type Database struct {
 	databaseUser     string
 	secret           string
 	labels           map[string]string
+	name             string
+	namespace        string
 }


### PR DESCRIPTION
 [database]Use databaseName for MariaDBDatabase Name

The CreateOrPatchDB() call used the caller's Name as the Name of the
MariaDBDatabase CR it created. But then later it tried to look it up by
using the Database.databaseName. When the two differs the CreateOrPatchDB
fails to create the DB.

Closes https://github.com/openstack-k8s-operators/lib-common/issues/65
Depends-on https://github.com/openstack-k8s-operators/lib-common/issues/67