### PR TITLE
Make requeue timeouts more configurable

### DIFF
--- a/modules/common/deployment/deployment.go
+++ b/modules/common/deployment/deployment.go
@@ -38,7 +38,7 @@ func NewDeployment(
 ) *Deployment {
 	return &Deployment{
 		deployment: deployment,
-		timeout:    timeout,
+		timeout:    time.Duration(timeout) * time.Second,
 	}
 }
 
@@ -74,8 +74,8 @@ func (d *Deployment) CreateOrPatch(
 	})
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
-			h.GetLogger().Info(fmt.Sprintf("Deployment %s not found, reconcile in %ds", deployment.Name, d.timeout))
-			return ctrl.Result{RequeueAfter: time.Duration(d.timeout) * time.Second}, nil
+			h.GetLogger().Info(fmt.Sprintf("Deployment %s not found, reconcile in %s", deployment.Name, d.timeout))
+			return ctrl.Result{RequeueAfter: d.timeout}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -109,6 +109,12 @@ func (d *Deployment) Delete(
 // GetDeployment - get the deployment object.
 func (d *Deployment) GetDeployment() appsv1.Deployment {
 	return *d.deployment
+}
+
+// SetTimeout defines the duration used for requeueing while waiting for the deployment
+// to finish.
+func (d *Deployment) SetTimeout(timeout time.Duration) {
+	d.timeout = timeout
 }
 
 // GetDeploymentWithName func

--- a/modules/common/deployment/types.go
+++ b/modules/common/deployment/types.go
@@ -16,10 +16,14 @@ limitations under the License.
 
 package deployment
 
-import appsv1 "k8s.io/api/apps/v1"
+import (
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
 
 // Deployment -
 type Deployment struct {
 	deployment *appsv1.Deployment
-	timeout    int
+	timeout    time.Duration
 }

--- a/modules/common/job/types.go
+++ b/modules/common/job/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package job
 
 import (
+	"time"
+
 	batchv1 "k8s.io/api/batch/v1"
 )
 
@@ -25,7 +27,7 @@ type Job struct {
 	job        *batchv1.Job
 	jobType    string
 	preserve   bool
-	timeout    int
+	timeout    time.Duration
 	beforeHash string
 	hash       string
 	changed    bool

--- a/modules/database/funcs.go
+++ b/modules/database/funcs.go
@@ -223,11 +223,12 @@ func (d *Database) CreateOrPatchDBByName(
 }
 
 //
-// WaitForDBCreated - wait until the MariaDBDatabase is initialized and reports Status.Completed == true
+// WaitForDBCreatedWithTimeout - wait until the MariaDBDatabase is initialized and reports Status.Completed == true
 //
-func (d *Database) WaitForDBCreated(
+func (d *Database) WaitForDBCreatedWithTimeout(
 	ctx context.Context,
 	h *helper.Helper,
+	requeueAfter time.Duration,
 ) (ctrl.Result, error) {
 
 	err := d.getDBWithName(
@@ -245,10 +246,20 @@ func (d *Database) WaitForDBCreated(
 			d.database,
 		)
 
-		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 
 	return ctrl.Result{}, nil
+}
+
+//
+// WaitForDBCreated - wait until the MariaDBDatabase is initialized and reports Status.Completed == true
+// Deprecated, use WaitForDBCreatedWithTimeout instead
+func (d *Database) WaitForDBCreated(
+	ctx context.Context,
+	h *helper.Helper,
+) (ctrl.Result, error) {
+	return d.WaitForDBCreatedWithTimeout(ctx, h, time.Second*5)
 }
 
 //


### PR DESCRIPTION
The overall goal is to make timeouts precisely configurable so that in envtest where DB, Job and Deployment creation success is simulated the test execution can be speeded up by setting a sub-second RequeueAfter value.

To achieve this:
* WaitForDBCreatedWithTimeout is introduced to take a timeout value in time.Duration instead of using a hard coded 5secs.

* Deployment and Job is changed to store time.Duration instead of seconds internally and a SetTimeout funcs are introduced to make that configurable