### PR TITLE
Do not log error for DB creation

### DIFF
--- a/modules/database/funcs.go
+++ b/modules/database/funcs.go
@@ -204,11 +204,8 @@ func (d *Database) CreateOrPatchDBByName(
 	}
 
 	if op != controllerutil.OperationResultNone {
-		return ctrl.Result{RequeueAfter: time.Second * 5}, util.WrapErrorForObject(
-			fmt.Sprintf("DB object %s created or patched", db.Name),
-			db,
-			err,
-		)
+		util.LogForObject(h, fmt.Sprintf("DB object %s created or patched", db.Name), db)
+		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 	}
 
 	err = d.getDBWithName(


### PR DESCRIPTION
Creating or updating a MariaDBDatabase should not be reported as error as it is not really an error condition. The controller just need to requeue the reconcilation to wait for the MariaDBDatabase reconciliation but should not log an error with a stack trace.