### PR TITLE
Do not delete the Job until it's hash is persisted

### DIFF
--- a/modules/common/job/job.go
+++ b/modules/common/job/job.go
@@ -41,16 +41,14 @@ const hashAnnotation = "hash"
 func NewJob(
 	job *batchv1.Job,
 	jobType string,
-	preserve bool,
-	timeout int,
+	timeout time.Duration,
 	beforeHash string,
 ) *Job {
 
 	return &Job{
 		job:        job,
 		jobType:    jobType,
-		preserve:   preserve,
-		timeout:    time.Duration(timeout) * time.Second, // timeout to set in s to reconcile
+		timeout:    timeout,
 		beforeHash: beforeHash,
 		changed:    false,
 	}
@@ -150,12 +148,6 @@ func (j *Job) HasChanged() bool {
 // GetHash func
 func (j *Job) GetHash() string {
 	return j.hash
-}
-
-// SetTimeout defines the duration used for requeueing while waiting for the job
-// to finish.
-func (j *Job) SetTimeout(timeout time.Duration) {
-	j.timeout = timeout
 }
 
 // DeleteJob func

--- a/modules/common/job/types.go
+++ b/modules/common/job/types.go
@@ -26,7 +26,6 @@ import (
 type Job struct {
 	job        *batchv1.Job
 	jobType    string
-	preserve   bool
 	timeout    time.Duration
 	beforeHash string
 	hash       string


### PR DESCRIPTION
We have a logic error around Job deletion.

1. controller calls DoJob() on lib-common's Job
2. lib-common waits for the Job to finish and if succeeds, it deletes the Job.
3. the controller calculates the hash of the Job and puts it to Status.Hash
4. the controller calls Status.Update() to persist the hash to the DB

If step 4. fails due to a conflict then the reconcile is requeued and the
controller will see that no Job exists (as it was deleted at 2.) and
recreates it. This means we can potentially run the same Job multiple
times if we are unlucky.

So this changes removed the automatic job deletion logic from DoJob and
instead provides a new DeleteAllSucceededJobs() call to the controllers
to use to clean up the Jobs.

**This is a breaking change**

The callers should do the following to adapt:
1) After DoJob() returned ctrl.Result{}, nil, (i.e. the Job succeeded)
   the callers should store the hash of the Job in its Status
2) The caller should persist the Status.
3) If persisting the Status succeeded then call DeleteAllSucceededJobs
   providing the hash of the Jobs to be deleted.

----
We took the opportunity and did other cleanups in the Job interface that are also breaking changes:

1) The Job.preserved field is removed from the NewJob() signature
   the Job cleanup needs to be done by the client anyhow.
2) The type of the timeout parameter of NewJob changed from int (seconds) to
   time.Duration to expose the fine grain configurability directly
   instead of calling the SetTimeout() separately.

Callers should do the following:
1) Adapt to the new signature of NewJob()

----

Adaptations:
- Nova: https://github.com/openstack-k8s-operators/nova-operator/pull/108
- Placement: https://github.com/openstack-k8s-operators/placement-operator/pull/51
- Keystone: https://github.com/openstack-k8s-operators/keystone-operator/pull/112
- Glance: https://github.com/openstack-k8s-operators/glance-operator/pull/66
- Cinder: https://github.com/openstack-k8s-operators/cinder-operator/pull/61
- Neutron: https://github.com/openstack-k8s-operators/neutron-operator/pull/44
- Octavia: https://github.com/openstack-k8s-operators/octavia-operator/pull/17
- Ironic: https://github.com/openstack-k8s-operators/ironic-operator/pull/25
- MariaDB: https://github.com/openstack-k8s-operators/mariadb-operator/pull/40