### PR TITLE
Default TTLSecondsAfterFinished on Jobs

### DIFF
--- a/modules/common/job/types.go
+++ b/modules/common/job/types.go
@@ -22,6 +22,10 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 )
 
+const (
+	defaultTTL int32 = 10 * 60 // 10 minutes
+)
+
 // Job -
 type Job struct {
 	job        *batchv1.Job


### PR DESCRIPTION
Currently lib-common automatically and immediately deletes the Job after it finished if preserve is set to false. However
* if the caller of DoJob fails to persist the fact that the Job is done (e.g. due to conflict) OR
* the caller's next reconcile reads stale data from cache seeing that the Job is not finished but also does not exists as it was already deleted
then the client has no way to decide that the Job does not need to be run again. This could lead to duplicate Job execution.

So this patch delays the automatic Job deletion with a default TTL of 10 minutes counted from the finish of the Job. We believe that this is plenty of time to allow the caller to successfully persist the Job state even if it has to retry it and to let the operator-sdk update the cache.

See the previous [fix attempt](https://github.com/openstack-k8s-operators/lib-common/pull/77) (a partial fix) and the [nova issue](https://github.com/openstack-k8s-operators/nova-operator/issues/110) about the stale read for more details.

Closes: https://github.com/openstack-k8s-operators/nova-operator/issues/110