### PR TITLE
[StatefulSet]Allow fine grained RequeueAfter value

### DIFF
--- a/modules/common/statefulset/statefulset.go
+++ b/modules/common/statefulset/statefulset.go
@@ -38,7 +38,7 @@ func NewStatefulSet(
 ) *StatefulSet {
 	return &StatefulSet{
 		statefulset: statefulset,
-		timeout:     timeout,
+		timeout:     time.Duration(timeout) * time.Second,
 	}
 }
 
@@ -75,8 +75,8 @@ func (s *StatefulSet) CreateOrPatch(
 	})
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
-			h.GetLogger().Info(fmt.Sprintf("StatefulSet %s not found, reconcile in %ds", statefulset.Name, s.timeout))
-			return ctrl.Result{RequeueAfter: time.Duration(s.timeout) * time.Second}, nil
+			h.GetLogger().Info(fmt.Sprintf("StatefulSet %s not found, reconcile in %s", statefulset.Name, s.timeout))
+			return ctrl.Result{RequeueAfter: s.timeout}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -127,4 +127,10 @@ func (s *StatefulSet) Delete(
 	}
 
 	return nil
+}
+
+// SetTimeout defines the duration used for requeueing while waiting for the
+// stateful set to exist.
+func (s *StatefulSet) SetTimeout(timeout time.Duration) {
+	s.timeout = timeout
 }

--- a/modules/common/statefulset/types.go
+++ b/modules/common/statefulset/types.go
@@ -16,10 +16,14 @@ limitations under the License.
 
 package statefulset
 
-import appsv1 "k8s.io/api/apps/v1"
+import (
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
 
 // StatefulSet -
 type StatefulSet struct {
 	statefulset *appsv1.StatefulSet
-	timeout     int
+	timeout     time.Duration
 }


### PR DESCRIPTION
Make the RequeueAfter timeout value configurable so that in an envtest environment it can be set to a lower than 1 second value to speed up the testing.