### PR TITLE
Add missing ServiceName to StatefulSet

### DIFF
--- a/modules/common/statefulset/statefulset.go
+++ b/modules/common/statefulset/statefulset.go
@@ -65,6 +65,7 @@ func (s *StatefulSet) CreateOrPatch(
 		statefulset.Labels = util.MergeStringMaps(statefulset.Labels, s.statefulset.Labels)
 		statefulset.Spec.Template = s.statefulset.Spec.Template
 		statefulset.Spec.Replicas = s.statefulset.Spec.Replicas
+		statefulset.Spec.ServiceName = s.statefulset.Spec.ServiceName
 
 		err := controllerutil.SetControllerReference(h.GetBeforeObject(), statefulset, h.GetScheme())
 		if err != nil {


### PR DESCRIPTION
ServiceName is required if a Service should govern a StatefulSet.