### PR TITLE
Add clusterIP to Service

### DIFF
--- a/modules/common/service/service.go
+++ b/modules/common/service/service.go
@@ -64,6 +64,7 @@ func GenericService(svcInfo *GenericServiceDetails) *corev1.Service {
 					Protocol: svcInfo.Port.Protocol,
 				},
 			},
+			ClusterIP:  svcInfo.ClusterIP,
 		},
 	}
 }

--- a/modules/common/service/types.go
+++ b/modules/common/service/types.go
@@ -31,6 +31,7 @@ type GenericServiceDetails struct {
 	Labels    map[string]string
 	Selector  map[string]string
 	Port      GenericServicePort
+	ClusterIP string
 }
 
 // GenericServicePort -


### PR DESCRIPTION
StatefulSets require a headless service to manage the network identity of the pods[1]. A headless service itself is defined by specifying "None" as clusterIP[2].

[1] k8s.io/docs/concepts/workloads/controllers/statefulset/#limitations [2] k8s.io/docs/concepts/services-networking/service/#headless-services