### PR TITLE
Fix logging if Secret not found

### DIFF
--- a/modules/common/secret/secret.go
+++ b/modules/common/secret/secret.go
@@ -363,12 +363,7 @@ func GetDataFromSecret(
 	secret, _, err := GetSecret(ctx, h, secretName, h.GetBeforeObject().GetNamespace())
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
-			util.LogForObject(
-				h,
-				fmt.Sprintf("%s secret does not exist", secretName),
-				secret,
-			)
-
+			h.GetLogger().Info(fmt.Sprintf("Secret %s not found, reconcile in %ds", secretName, requeueTimeout))
 			return data, ctrl.Result{RequeueAfter: time.Duration(requeueTimeout) * time.Second}, nil
 		}
 


### PR DESCRIPTION
GetSecret returns nil as secret if no Secret is found, and this raises a panic in util.logObjectParams with a runtime error.

Also changed the log message to be more inline with other similar messages.