### PR TITLE
Introduce operator-lint

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -32,3 +32,16 @@ jobs:
         uses: actions/checkout@v2
       - name: Run golangci lint
         run: make golangci
+
+  operator-lint:
+    name: operator-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18.x
+      - name: Checkout project code
+        uses: actions/checkout@v2
+      - name: Run operator-lint
+        run: make operator-lint

--- a/Makefile
+++ b/Makefile
@@ -124,3 +124,14 @@ golint: get-ci-tools
 gowork:
 	test -f go.work || go work init
 	for mod in $(shell find modules -maxdepth 1 -mindepth 1 -type d); do go work use $$mod; done
+
+.PHONY: operator-lint
+operator-lint: gowork ## Runs operator-lint
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.1.0
+	for mod in $(shell find modules/ -maxdepth 1 -mindepth 1 -type d); do \
+		set -x ; \
+		if [ $$mod == "modules/archive" ]; then continue; fi ; \
+        pushd ./$$mod ; \
+        go vet -vettool=$(LOCALBIN)/operator-lint ./... || exit 1 ; \
+        popd ; \
+    done


### PR DESCRIPTION
As lib-common now has test helpers using gomega we enable operator-lint that has one important check for gomega code T001.

[1] https://github.com/gibizer/operator-lint/