### PR TITLE
Fix minor format according to go fmt

### DIFF
--- a/modules/common/service/service.go
+++ b/modules/common/service/service.go
@@ -64,7 +64,7 @@ func GenericService(svcInfo *GenericServiceDetails) *corev1.Service {
 					Protocol: svcInfo.Port.Protocol,
 				},
 			},
-			ClusterIP:  svcInfo.ClusterIP,
+			ClusterIP: svcInfo.ClusterIP,
 		},
 	}
 }


### PR DESCRIPTION
This change fixes one bad formatting detected by `go fmt`.