### PR TITLE
Add annotations package with GetNADAnnotation

### DIFF
--- a/modules/common/annotations/network.go
+++ b/modules/common/annotations/network.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2023 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// NetworkAttachmentAnnot pod annotation for network-attachment-definition
+// (mschuppert) for now specify the const from "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+// here to not have that dependency. If there is more we get from there could import it
+const NetworkAttachmentAnnot string = "k8s.v1.cni.cncf.io/networks"
+
+type net struct {
+	Name      string
+	Namespace string
+}
+
+// GetNADAnnotation returns pod annotation for network-attachment-definition
+// e.g. k8s.v1.cni.cncf.io/networks: '[{"name": "internalapi", "namespace": "openstack"},{"name": "storage", "namespace": "openstack"}]'
+func GetNADAnnotation(namespace string, nads []string) (map[string]string, error) {
+
+	netAnnotations := []net{}
+	for _, nad := range nads {
+		netAnnotations = append(
+			netAnnotations,
+			net{
+				Name:      nad,
+				Namespace: namespace,
+			},
+		)
+	}
+
+	networks, err := json.Marshal(netAnnotations)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode networks %s into json: %w", nads, err)
+	}
+
+	return map[string]string{NetworkAttachmentAnnot: string(networks)}, nil
+}

--- a/modules/common/annotations/network_test.go
+++ b/modules/common/annotations/network_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetNADAnnotation(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		networks  []string
+		namespace string
+		want      map[string]string
+	}{
+		{
+			name:      "Single network",
+			networks:  []string{},
+			namespace: "foo",
+			want:      map[string]string{NetworkAttachmentAnnot: "[]"},
+		},
+		{
+			name:      "Single network",
+			networks:  []string{"one"},
+			namespace: "foo",
+			want:      map[string]string{NetworkAttachmentAnnot: "[{\"Name\":\"one\",\"Namespace\":\"foo\"}]"},
+		},
+		{
+			name:      "Multiple networks",
+			networks:  []string{"one", "two"},
+			namespace: "foo",
+			want:      map[string]string{NetworkAttachmentAnnot: "[{\"Name\":\"one\",\"Namespace\":\"foo\"},{\"Name\":\"two\",\"Namespace\":\"foo\"}]"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			networkAnnotation, err := GetNADAnnotation(tt.namespace, tt.networks)
+			g.Expect(err).To(BeNil())
+			g.Expect(networkAnnotation).To(HaveLen(len(tt.want)))
+			g.Expect(networkAnnotation).To(BeEquivalentTo(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
To attach additional interfaces via multus to resources the `k8s.v1.cni.cncf.io/networks` annotation needs to be added to the pod spec. e.g.

k8s.v1.cni.cncf.io/networks: '[{"name": "internalapi", "namespace": "openstack"},{"name": "storage", "namespace": "openstack"}]'

GetNADAnnotation() returns this annotation based on the namespace and the list of network-attachment-definitions passed in.