### PR TITLE
Use time.Duration for timeout

### DIFF
--- a/modules/common/configmap/configmap.go
+++ b/modules/common/configmap/configmap.go
@@ -238,13 +238,13 @@ func GetConfigMapAndHashWithName(
 //
 // GetConfigMap - Get config map
 //
-// if the config map is not found, requeue after requeueTimeout in seconds
+// if the config map is not found, requeue after requeueTimeout
 func GetConfigMap(
 	ctx context.Context,
 	h *helper.Helper,
 	object client.Object,
 	configMapName string,
-	requeueTimeout int,
+	requeueTimeout time.Duration,
 ) (*corev1.ConfigMap, ctrl.Result, error) {
 
 	configMap := &corev1.ConfigMap{}
@@ -254,7 +254,7 @@ func GetConfigMap(
 			msg := fmt.Sprintf("%s config map does not exist: %v", configMapName, err)
 			util.LogForObject(h, msg, object)
 
-			return configMap, ctrl.Result{RequeueAfter: time.Duration(requeueTimeout) * time.Second}, nil
+			return configMap, ctrl.Result{RequeueAfter: requeueTimeout}, nil
 		}
 		msg := fmt.Sprintf("Error getting %s config map: %v", configMapName, err)
 		err = util.WrapErrorForObject(msg, object, err)

--- a/modules/common/cronjob/cronjob.go
+++ b/modules/common/cronjob/cronjob.go
@@ -87,12 +87,6 @@ func (cj *CronJob) GetCronJob() batchv1.CronJob {
 	return *cj.cronjob
 }
 
-// SetTimeout defines the duration used for requeueing while waiting for the cronjob
-// to finish.
-func (cj *CronJob) SetTimeout(timeout time.Duration) {
-	cj.timeout = timeout
-}
-
 // GetCronJobWithName func
 func GetCronJobWithName(
 	ctx context.Context,

--- a/modules/common/deployment/deployment.go
+++ b/modules/common/deployment/deployment.go
@@ -34,11 +34,11 @@ import (
 // NewDeployment returns an initialized Deployment.
 func NewDeployment(
 	deployment *appsv1.Deployment,
-	timeout int,
+	timeout time.Duration,
 ) *Deployment {
 	return &Deployment{
 		deployment: deployment,
-		timeout:    time.Duration(timeout) * time.Second,
+		timeout:    timeout,
 	}
 }
 
@@ -109,12 +109,6 @@ func (d *Deployment) Delete(
 // GetDeployment - get the deployment object.
 func (d *Deployment) GetDeployment() appsv1.Deployment {
 	return *d.deployment
-}
-
-// SetTimeout defines the duration used for requeueing while waiting for the deployment
-// to finish.
-func (d *Deployment) SetTimeout(timeout time.Duration) {
-	d.timeout = timeout
 }
 
 // GetDeploymentWithName func

--- a/modules/common/job/job.go
+++ b/modules/common/job/job.go
@@ -39,7 +39,7 @@ func NewJob(
 	job *batchv1.Job,
 	jobType string,
 	preserve bool,
-	timeout int,
+	timeout time.Duration,
 	beforeHash string,
 ) *Job {
 
@@ -47,7 +47,7 @@ func NewJob(
 		job:        job,
 		jobType:    jobType,
 		preserve:   preserve,
-		timeout:    time.Duration(timeout) * time.Second, // timeout to set in s to reconcile
+		timeout:    timeout,
 		beforeHash: beforeHash,
 		changed:    false,
 	}
@@ -197,12 +197,6 @@ func (j *Job) HasChanged() bool {
 // GetHash func
 func (j *Job) GetHash() string {
 	return j.hash
-}
-
-// SetTimeout defines the duration used for requeueing while waiting for the job
-// to finish.
-func (j *Job) SetTimeout(timeout time.Duration) {
-	j.timeout = timeout
 }
 
 // DeleteJob func

--- a/modules/common/pvc/pvc.go
+++ b/modules/common/pvc/pvc.go
@@ -34,7 +34,7 @@ import (
 // NewPvc returns an initialized Pvc.
 func NewPvc(
 	pvc *corev1.PersistentVolumeClaim,
-	timeout int,
+	timeout time.Duration,
 ) *Pvc {
 	return &Pvc{
 		pvc:     pvc,
@@ -79,8 +79,8 @@ func (p *Pvc) CreateOrPatch(
 
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
-			h.GetLogger().Info(fmt.Sprintf("Pvc %s not found, reconcile in %ds", pvc.Name, p.timeout))
-			return ctrl.Result{RequeueAfter: time.Duration(p.timeout) * time.Second}, nil
+			h.GetLogger().Info(fmt.Sprintf("Pvc %s not found, reconcile in %s", pvc.Name, p.timeout))
+			return ctrl.Result{RequeueAfter: p.timeout}, nil
 		}
 		return ctrl.Result{}, err
 	}

--- a/modules/common/pvc/types.go
+++ b/modules/common/pvc/types.go
@@ -16,10 +16,14 @@ limitations under the License.
 
 package pvc
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 // Pvc -
 type Pvc struct {
 	pvc     *corev1.PersistentVolumeClaim
-	timeout int
+	timeout time.Duration
 }

--- a/modules/common/route/route.go
+++ b/modules/common/route/route.go
@@ -36,7 +36,7 @@ import (
 func NewRoute(
 	route *routev1.Route,
 	labels map[string]string,
-	timeout int,
+	timeout time.Duration,
 ) *Route {
 	return &Route{
 		route:   route,
@@ -98,8 +98,8 @@ func (r *Route) CreateOrPatch(
 	})
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
-			h.GetLogger().Info(fmt.Sprintf("Route %s not found, reconcile in %ds", route.Name, r.timeout))
-			return ctrl.Result{RequeueAfter: time.Duration(r.timeout) * time.Second}, nil
+			h.GetLogger().Info(fmt.Sprintf("Route %s not found, reconcile in %s", route.Name, r.timeout))
+			return ctrl.Result{RequeueAfter: r.timeout}, nil
 		}
 		return ctrl.Result{}, err
 	}

--- a/modules/common/route/types.go
+++ b/modules/common/route/types.go
@@ -16,12 +16,16 @@ limitations under the License.
 
 package route
 
-import routev1 "github.com/openshift/api/route/v1"
+import (
+	"time"
+
+	routev1 "github.com/openshift/api/route/v1"
+)
 
 // Route -
 type Route struct {
 	route    *routev1.Route
-	timeout  int
+	timeout  time.Duration
 	hostname string
 }
 

--- a/modules/common/secret/secret.go
+++ b/modules/common/secret/secret.go
@@ -349,12 +349,12 @@ func DeleteSecretsWithName(
 //
 // GetDataFromSecret - Get data from Secret
 //
-// if the secret or data is not found, requeue after requeueTimeout in seconds
+// if the secret or data is not found, requeue after requeueTimeout
 func GetDataFromSecret(
 	ctx context.Context,
 	h *helper.Helper,
 	secretName string,
-	requeueTimeout int,
+	requeueTimeout time.Duration,
 	key string,
 ) (string, ctrl.Result, error) {
 
@@ -363,8 +363,8 @@ func GetDataFromSecret(
 	secret, _, err := GetSecret(ctx, h, secretName, h.GetBeforeObject().GetNamespace())
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
-			h.GetLogger().Info(fmt.Sprintf("Secret %s not found, reconcile in %ds", secretName, requeueTimeout))
-			return data, ctrl.Result{RequeueAfter: time.Duration(requeueTimeout) * time.Second}, nil
+			h.GetLogger().Info(fmt.Sprintf("Secret %s not found, reconcile in %s", secretName, requeueTimeout))
+			return data, ctrl.Result{RequeueAfter: requeueTimeout}, nil
 		}
 
 		return data, ctrl.Result{}, util.WrapErrorForObject(

--- a/modules/common/service/service.go
+++ b/modules/common/service/service.go
@@ -37,7 +37,7 @@ import (
 func NewService(
 	service *corev1.Service,
 	labels map[string]string,
-	timeout int,
+	timeout time.Duration,
 ) *Service {
 	return &Service{
 		service: service,
@@ -95,8 +95,8 @@ func (s *Service) CreateOrPatch(
 	})
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
-			h.GetLogger().Info(fmt.Sprintf("Service %s not found, reconcile in %ds", service.Name, s.timeout))
-			return ctrl.Result{RequeueAfter: time.Duration(s.timeout) * time.Second}, nil
+			h.GetLogger().Info(fmt.Sprintf("Service %s not found, reconcile in %s", service.Name, s.timeout))
+			return ctrl.Result{RequeueAfter: s.timeout}, nil
 		}
 		return ctrl.Result{}, err
 	}

--- a/modules/common/service/types.go
+++ b/modules/common/service/types.go
@@ -16,12 +16,16 @@ limitations under the License.
 
 package service
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 // Service -
 type Service struct {
 	service *corev1.Service
-	timeout int
+	timeout time.Duration
 }
 
 // GenericServiceDetails -

--- a/modules/common/statefulset/statefulset.go
+++ b/modules/common/statefulset/statefulset.go
@@ -34,11 +34,11 @@ import (
 // NewStatefulSet returns an initialized NewStatefulset.
 func NewStatefulSet(
 	statefulset *appsv1.StatefulSet,
-	timeout int,
+	timeout time.Duration,
 ) *StatefulSet {
 	return &StatefulSet{
 		statefulset: statefulset,
-		timeout:     time.Duration(timeout) * time.Second,
+		timeout:     timeout,
 	}
 }
 
@@ -137,10 +137,4 @@ func (s *StatefulSet) Delete(
 	}
 
 	return nil
-}
-
-// SetTimeout defines the duration used for requeueing while waiting for the
-// stateful set to exist.
-func (s *StatefulSet) SetTimeout(timeout time.Duration) {
-	s.timeout = timeout
 }


### PR DESCRIPTION
instead of int. This allows us to use more fine grained timeout value such as 0.1, and encodes the unit in the type itself.