### PR TITLE
Add MetalLB service type

### DIFF
--- a/modules/common/annotations/network.go
+++ b/modules/common/annotations/network.go
@@ -33,6 +33,7 @@ type net struct {
 
 // GetNADAnnotation returns pod annotation for network-attachment-definition
 // e.g. k8s.v1.cni.cncf.io/networks: '[{"name": "internalapi", "namespace": "openstack"},{"name": "storage", "namespace": "openstack"}]'
+// DEPRECATED in favor of CreateNetworksAnnotation from network pkg
 func GetNADAnnotation(namespace string, nads []string) (map[string]string, error) {
 
 	netAnnotations := []net{}

--- a/modules/common/condition/conditions.go
+++ b/modules/common/condition/conditions.go
@@ -18,9 +18,7 @@ limitations under the License.
 
 package condition
 
-//
 // Common Condition Types used by API objects.
-//
 const (
 	// ReadyCondition defines the Ready condition type that summarizes the operational state of an API object.
 	ReadyCondition Type = "Ready"
@@ -51,11 +49,12 @@ const (
 
 	// KeystoneEndpointReadyCondition This condition is mirrored from the Ready condition in the keystoneendpoint ref object to the service API.
 	KeystoneEndpointReadyCondition Type = "KeystoneEndpointReady"
+
+	// NetworkAttachmentsReadyCondition Status=True condition when all pods k8s.v1.cni.cncf.io/network-status shows configured interfaces for all the NetworkAttachments with IP address
+	NetworkAttachmentsReadyCondition Type = "NetworkAttachmentsReady"
 )
 
-//
 // Common Reasons used by API objects.
-//
 const (
 	// RequestedReason (Severity=Info) documents a condition not in Status=True because the underlying object is not ready.
 	RequestedReason = "Requested"
@@ -84,9 +83,7 @@ const (
 	DeletedReason = "Deleted"
 )
 
-//
 // Common Messages used by API objects.
-//
 const (
 	//
 	// Overall Ready Condition messages
@@ -198,4 +195,19 @@ const (
 
 	// DeploymentReadyErrorMessage
 	DeploymentReadyErrorMessage = "Deployment error occured %s"
+
+	//
+	// NetworkAttachmentsReady condition messages
+	//
+	// NetworkAttachmentsReadyInitMessage
+	NetworkAttachmentsReadyInitMessage = "NetworkAttachments not started"
+
+	// NetworkAttachmentsReadyMessage
+	NetworkAttachmentsReadyMessage = "NetworkAttachments completed"
+
+	// NetworkAttachmentsReadyWaitingMessage
+	NetworkAttachmentsReadyWaitingMessage = "NetworkAttachment resources missing: %s"
+
+	// NetworkAttachmentsReadyErrorMessage
+	NetworkAttachmentsReadyErrorMessage = "NetworkAttachments error occured %s"
 )

--- a/modules/common/endpoint/endpoint.go
+++ b/modules/common/endpoint/endpoint.go
@@ -48,6 +48,22 @@ type Data struct {
 	Port int32
 	// An optional path suffix to append to route hostname when forming Keystone endpoint URLs
 	Path string
+	// details for metallb service generation
+	MetalLB *MetalLBData
+}
+
+// MetalLBData - information specific to creating the MetalLB service
+type MetalLBData struct {
+	// Name of the metallb IpAddressPool
+	IPAddressPool string
+	// use shared IP for the service
+	SharedIP bool
+	// sharing key which gets set as the annotation on the LoadBalancer service.
+	// Services which share the same VIP must have the same SharedIPKey. Gets default to the IPAddressPool if
+	// SharedIP is true, but no SharedIPKey set.
+	SharedIPKey string
+	// if set request these IPs via MetalLBLoadBalancerIPs, using a list for dual stack (ipv4/ipv6)
+	LoadBalancerIPs []string
 }
 
 // ExposeEndpoints - creates services, routes and returns a map of created openstack endpoint
@@ -70,58 +86,107 @@ func ExposeEndpoints(
 				string(endpointType): "true",
 			},
 		)
-		//
-		// Create the service if none exists
-		//
-		svc := service.NewService(
-			service.GenericService(&service.GenericServiceDetails{
-				Name:      endpointName,
-				Namespace: h.GetBeforeObject().GetNamespace(),
-				Labels:    exportLabels,
-				Selector:  endpointSelector,
-				Port: service.GenericServicePort{
-					Name:     endpointName,
-					Port:     data.Port,
-					Protocol: corev1.ProtocolTCP,
-				}}),
-			exportLabels,
-			timeout,
-		)
-		ctrlResult, err := svc.CreateOrPatch(ctx, h)
-		if err != nil {
-			return endpointMap, ctrlResult, err
-		} else if (ctrlResult != ctrl.Result{}) {
-			return endpointMap, ctrlResult, nil
+
+		// Create metallb service if specified, otherwise create a route
+		var hostname string
+		if data.MetalLB != nil {
+			annotations := map[string]string{
+				service.MetalLBAddressPoolAnnotation: data.MetalLB.IPAddressPool,
+			}
+			if len(data.MetalLB.LoadBalancerIPs) > 0 {
+				annotations[service.MetalLBLoadBalancerIPs] = strings.Join(data.MetalLB.LoadBalancerIPs, ",")
+			}
+			if data.MetalLB.SharedIP {
+				if data.MetalLB.SharedIPKey == "" {
+					annotations[service.MetalLBAllowSharedIPAnnotation] = data.MetalLB.IPAddressPool
+				} else {
+					annotations[service.MetalLBAllowSharedIPAnnotation] = data.MetalLB.SharedIPKey
+				}
+			}
+
+			// Create the service
+			svc := service.NewService(
+				service.MetalLBService(&service.MetalLBServiceDetails{
+					Name:        endpointName,
+					Namespace:   h.GetBeforeObject().GetNamespace(),
+					Annotations: annotations,
+					Labels:      exportLabels,
+					Selector:    endpointSelector,
+					Port: service.GenericServicePort{
+						Name:     endpointName,
+						Port:     data.Port,
+						Protocol: corev1.ProtocolTCP,
+					},
+				}),
+				exportLabels,
+				timeout,
+			)
+			ctrlResult, err := svc.CreateOrPatch(ctx, h)
+			if err != nil {
+				return endpointMap, ctrlResult, err
+			} else if (ctrlResult != ctrl.Result{}) {
+				return endpointMap, ctrlResult, nil
+			}
+			// create service - end
+
+			hostname = svc.GetServiceHostnamePort()
+		} else {
+
+			// Create the service
+			svc := service.NewService(
+				service.GenericService(&service.GenericServiceDetails{
+					Name:      endpointName,
+					Namespace: h.GetBeforeObject().GetNamespace(),
+					Labels:    exportLabels,
+					Selector:  endpointSelector,
+					Port: service.GenericServicePort{
+						Name:     endpointName,
+						Port:     data.Port,
+						Protocol: corev1.ProtocolTCP,
+					}}),
+				exportLabels,
+				5,
+			)
+			ctrlResult, err := svc.CreateOrPatch(ctx, h)
+			if err != nil {
+				return endpointMap, ctrlResult, err
+			} else if (ctrlResult != ctrl.Result{}) {
+				return endpointMap, ctrlResult, nil
+			}
+			// create service - end
+
+			hostname = svc.GetServiceHostnamePort()
+
+			// Create the route if it is public endpoint
+			if endpointType == EndpointPublic {
+				// Create the route
+				// TODO TLS
+				route := route.NewRoute(
+					route.GenericRoute(&route.GenericRouteDetails{
+						Name:           endpointName,
+						Namespace:      h.GetBeforeObject().GetNamespace(),
+						Labels:         exportLabels,
+						ServiceName:    endpointName,
+						TargetPortName: endpointName,
+					}),
+					exportLabels,
+					timeout,
+				)
+
+				ctrlResult, err = route.CreateOrPatch(ctx, h)
+				if err != nil {
+					return endpointMap, ctrlResult, err
+				} else if (ctrlResult != ctrl.Result{}) {
+					return endpointMap, ctrlResult, nil
+				}
+				// create route - end
+
+				hostname = route.GetHostname()
+			}
 		}
-		// create service - end
 
-		// Create the route if none exists
-		// TODO TLS
-		route := route.NewRoute(
-			route.GenericRoute(&route.GenericRouteDetails{
-				Name:           endpointName,
-				Namespace:      h.GetBeforeObject().GetNamespace(),
-				Labels:         exportLabels,
-				ServiceName:    endpointName,
-				TargetPortName: endpointName,
-			}),
-			exportLabels,
-			timeout,
-		)
-
-		ctrlResult, err = route.CreateOrPatch(ctx, h)
-		if err != nil {
-			return endpointMap, ctrlResult, err
-		} else if (ctrlResult != ctrl.Result{}) {
-			return endpointMap, ctrlResult, nil
-		}
-		// create route - end
-
-		//
 		// Update instance status with service endpoint url from route host information
-		//
 		var protocol string
-		hostname := route.GetHostname()
 
 		// TODO: need to support https default here
 		if !strings.HasPrefix(hostname, "http") {
@@ -134,7 +199,7 @@ func ExposeEndpoints(
 		// is invalid without being encoded, but they should not be encoded in the actual endpoint
 		apiEndpoint, err := url.Parse(protocol + hostname)
 		if err != nil {
-			return endpointMap, ctrlResult, err
+			return endpointMap, ctrl.Result{}, err
 		}
 		endpointMap[string(endpointType)] = apiEndpoint.String() + data.Path
 	}

--- a/modules/common/go.mod
+++ b/modules/common/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.3
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/onsi/gomega v1.24.1
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/modules/common/go.sum
+++ b/modules/common/go.sum
@@ -178,6 +178,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0 h1:VzM3TYHDgqPkettiP6I6q2jOeQFL4nrJM+UcAc4f6Fs=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0/go.mod h1:nqCI7aelBJU61wiBeeZWJ6oi4bJy5nrjkM6lWIMA4j0=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/modules/common/networkattachment/networkattachment.go
+++ b/modules/common/networkattachment/networkattachment.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2023 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkattachment
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/pod"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// GetNADWithName - Get network-attachment-definition with name in namespace
+func GetNADWithName(
+	ctx context.Context,
+	h *helper.Helper,
+	name string,
+	namespace string,
+) (*networkv1.NetworkAttachmentDefinition, error) {
+
+	nad := &networkv1.NetworkAttachmentDefinition{}
+
+	err := h.GetClient().Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, nad)
+	if err != nil {
+		err = fmt.Errorf("Error getting network-attachment-definition %s/%s - %w", name, namespace, err)
+
+		return nil, err
+	}
+
+	return nad, nil
+}
+
+// CreateNetworksAnnotation returns pod annotation for network-attachment-definition list
+// e.g. k8s.v1.cni.cncf.io/networks: '[{"name": "internalapi", "namespace": "openstack"},{"name": "storage", "namespace": "openstack"}]'
+func CreateNetworksAnnotation(namespace string, nads []string) (map[string]string, error) {
+
+	netAnnotations := []networkv1.NetworkSelectionElement{}
+	for _, nad := range nads {
+		netAnnotations = append(
+			netAnnotations,
+			networkv1.NetworkSelectionElement{
+				Name:      nad,
+				Namespace: namespace,
+			},
+		)
+	}
+
+	networks, err := json.Marshal(netAnnotations)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode networks %s into json: %w", nads, err)
+	}
+
+	return map[string]string{networkv1.NetworkAttachmentAnnot: string(networks)}, nil
+}
+
+// GetNetworkStatusFromAnnotation returns NetworkStatus list with networking details the pods are attached to
+func GetNetworkStatusFromAnnotation(annotations map[string]string) ([]networkv1.NetworkStatus, error) {
+
+	var netStatus []networkv1.NetworkStatus
+
+	if netStatusAnnotation, ok := annotations[networkv1.NetworkStatusAnnot]; ok {
+		err := json.Unmarshal([]byte(netStatusAnnotation), &netStatus)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode networks status %s: %w", netStatusAnnotation, err)
+		}
+	}
+
+	return netStatus, nil
+}
+
+// VerifyNetworkStatusFromAnnotation - verifies if NetworkStatus annotation for the pods of a deployment,
+// pods identified via the service label selector, matches the passed in network attachments and the number of
+// per network IPs the ready count of the deployment. Return true if count matches with the list of IPs per network.
+func VerifyNetworkStatusFromAnnotation(
+	ctx context.Context,
+	helper *helper.Helper,
+	networkAttachments []string,
+	serviceLabels map[string]string,
+	readyCount int32,
+) (bool, map[string][]string, error) {
+
+	networkReady := true
+	networkAttachmentStatus := map[string][]string{}
+	if len(networkAttachments) > 0 {
+		podList, err := pod.GetPodListWithLabel(ctx, helper, helper.GetBeforeObject().GetNamespace(), serviceLabels)
+		if err != nil {
+			return false, networkAttachmentStatus, err
+		}
+
+		for _, pod := range podList.Items {
+			netsStatus, err := GetNetworkStatusFromAnnotation(pod.Annotations)
+			if err != nil {
+				return networkReady, networkAttachmentStatus, err
+			}
+			for _, netStat := range netsStatus {
+				networkAttachmentStatus[netStat.Name] = append(networkAttachmentStatus[netStat.Name], netStat.IPs...)
+			}
+		}
+
+		for _, net := range networkAttachmentStatus {
+			if len(net) < int(readyCount) {
+				networkReady = false
+				break
+			}
+		}
+	}
+
+	return networkReady, networkAttachmentStatus, nil
+}

--- a/modules/common/networkattachment/networkattachment_test.go
+++ b/modules/common/networkattachment/networkattachment_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2023 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkattachment
+
+import (
+	"testing"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCreateNetworksAnnotation(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		networks  []string
+		namespace string
+		want      map[string]string
+	}{
+		{
+			name:      "No network",
+			networks:  []string{},
+			namespace: "foo",
+			want:      map[string]string{networkv1.NetworkAttachmentAnnot: "[]"},
+		},
+		{
+			name:      "Single network",
+			networks:  []string{"one"},
+			namespace: "foo",
+			want:      map[string]string{networkv1.NetworkAttachmentAnnot: "[{\"name\":\"one\",\"namespace\":\"foo\"}]"},
+		},
+		{
+			name:      "Multiple networks",
+			networks:  []string{"one", "two"},
+			namespace: "foo",
+			want:      map[string]string{networkv1.NetworkAttachmentAnnot: "[{\"name\":\"one\",\"namespace\":\"foo\"},{\"name\":\"two\",\"namespace\":\"foo\"}]"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			networkAnnotation, err := CreateNetworksAnnotation(tt.namespace, tt.networks)
+			g.Expect(err).To(BeNil())
+			g.Expect(networkAnnotation).To(HaveLen(len(tt.want)))
+			g.Expect(networkAnnotation).To(BeEquivalentTo(tt.want))
+		})
+	}
+}
+
+func TestGetNetworkStatusFromAnnotation(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        []networkv1.NetworkStatus
+	}{
+		{
+			name:        "Empty annotation",
+			annotations: map[string]string{},
+			want:        nil,
+		},
+		{
+			name: "just pod network",
+			annotations: map[string]string{
+				"k8s.v1.cni.cncf.io/network-status":  "[{\n    \"name\": \"openshift-sdn\",\n    \"interface\": \"eth0\",\n    \"ips\": [\n        \"10.131.0.16\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n}]",
+				"k8s.v1.cni.cncf.io/networks-status": "[{\n    \"name\": \"openshift-sdn\",\n    \"interface\": \"eth0\",\n    \"ips\": [\n        \"10.131.0.16\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n}]",
+			},
+			want: []networkv1.NetworkStatus{
+				{
+					Name:       "openshift-sdn",
+					Interface:  "eth0",
+					IPs:        []string{"10.131.0.16"},
+					Mac:        "",
+					Default:    true,
+					DNS:        networkv1.DNS{Nameservers: nil, Domain: "", Search: nil, Options: nil},
+					DeviceInfo: nil,
+					Gateway:    nil,
+				},
+			},
+		},
+		{
+			name: "with additional networkAttachment",
+			annotations: map[string]string{
+				"k8s.v1.cni.cncf.io/network-status":  "[{\n    \"name\": \"openshift-sdn\",\n    \"interface\": \"eth0\",\n    \"ips\": [\n        \"10.130.0.16\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n},{\n    \"name\": \"openstack/internalapi\",\n    \"interface\": \"net1\",\n    \"ips\": [\n        \"172.17.0.226\"\n    ],\n    \"mac\": \"a2:ef:bb:ae:65:45\",\n    \"dns\": {}\n}]",
+				"k8s.v1.cni.cncf.io/networks":        "[{\"name\":\"internalapi\",\"namespace\":\"openstack\"}]",
+				"k8s.v1.cni.cncf.io/networks-status": "[{\n    \"name\": \"openshift-sdn\",\n    \"interface\": \"eth0\",\n    \"ips\": [\n        \"10.130.0.16\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n},{\n    \"name\": \"openstack/internalapi\",\n    \"interface\": \"net1\",\n    \"ips\": [\n        \"172.17.0.226\"\n    ],\n    \"mac\": \"a2:ef:bb:ae:65:45\",\n    \"dns\": {}\n}]",
+			},
+			want: []networkv1.NetworkStatus{
+				{
+					Name:       "openshift-sdn",
+					Interface:  "eth0",
+					IPs:        []string{"10.130.0.16"},
+					Mac:        "",
+					Default:    true,
+					DNS:        networkv1.DNS{Nameservers: nil, Domain: "", Search: nil, Options: nil},
+					DeviceInfo: nil,
+					Gateway:    nil,
+				},
+				{
+					Name:       "openstack/internalapi",
+					Interface:  "net1",
+					IPs:        []string{"172.17.0.226"},
+					Mac:        "a2:ef:bb:ae:65:45",
+					Default:    false,
+					DNS:        networkv1.DNS{Nameservers: nil, Domain: "", Search: nil, Options: nil},
+					DeviceInfo: nil,
+					Gateway:    nil,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			networkStatus, err := GetNetworkStatusFromAnnotation(tt.annotations)
+			g.Expect(err).To(BeNil())
+			g.Expect(networkStatus).To(HaveLen(len(tt.want)))
+			g.Expect(networkStatus).To(BeEquivalentTo(tt.want))
+		})
+	}
+
+}

--- a/modules/common/service/types.go
+++ b/modules/common/service/types.go
@@ -24,8 +24,11 @@ import (
 
 // Service -
 type Service struct {
-	service *corev1.Service
-	timeout time.Duration
+	service         *corev1.Service
+	timeout         time.Duration
+	clusterIPs      []string
+	externalIPs     []string
+	serviceHostname string
 }
 
 // GenericServiceDetails -
@@ -44,3 +47,23 @@ type GenericServicePort struct {
 	Port     int32
 	Protocol corev1.Protocol // corev1.ProtocolTCP/ corev1.ProtocolUDP/ corev1.ProtocolSCTP - https://pkg.go.dev/k8s.io/api@v0.23.6/core/v1#Protocol
 }
+
+// MetalLBServiceDetails -
+type MetalLBServiceDetails struct {
+	Name            string
+	Namespace       string
+	Annotations     map[string]string
+	Labels          map[string]string
+	Selector        map[string]string
+	Port            GenericServicePort
+	LoadBalancerIPs []string
+}
+
+const (
+	// MetalLBAddressPoolAnnotation -
+	MetalLBAddressPoolAnnotation = "metallb.universe.tf/address-pool"
+	// MetalLBAllowSharedIPAnnotation -
+	MetalLBAllowSharedIPAnnotation = "metallb.universe.tf/allow-shared-ip"
+	// MetalLBLoadBalancerIPs -
+	MetalLBLoadBalancerIPs = "metallb.universe.tf/loadBalancerIPs"
+)


### PR DESCRIPTION
Adds a MetalLBService type to create its LoadBalancer service. Also extends the endpoint Data with MetalLBData with the required input to create the MetalLB service.