### PR TITLE
Add finalizer on MariaDB instance

### DIFF
--- a/modules/database/types.go
+++ b/modules/database/types.go
@@ -27,6 +27,7 @@ const (
 
 // Database -
 type Database struct {
+	dbInstance       *mariadbv1.MariaDB
 	database         *mariadbv1.MariaDBDatabase
 	databaseHostname string
 	databaseName     string


### PR DESCRIPTION
This would ensure that MariaDB instance can't
be deleted before the services. Adds dbInstance
field to Database struct and then adds/removes
finalizer on it for the service as required.