### PR TITLE
Add helper functions to manage commma-separated list

### DIFF
--- a/modules/common/util/string.go
+++ b/modules/common/util/string.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package util
 
+import (
+	"sort"
+	"strings"
+)
+
 // StringInSlice - is string in slice
 func StringInSlice(a string, list []string) bool {
 	for _, b := range list {
@@ -24,4 +29,13 @@ func StringInSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+func DumpListToString(list []string) string {
+	sort.Strings(list)
+	return strings.Join(list[:], ",")
+}
+
+func LoadListFromString(a string) []string {
+	return strings.Split(a, ",")
 }

--- a/modules/common/util/string_test.go
+++ b/modules/common/util/string_test.go
@@ -41,3 +41,55 @@ func TestStringInSlice(t *testing.T) {
 		})
 	}
 }
+
+func TestDumpListToString(t *testing.T) {
+	tests := []struct {
+		name string
+		data []string
+		want string
+	}{
+		{
+			name: "Dump list to string",
+			data: []string{"c", "a", "b"},
+			want: "a,b,c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			b := DumpListToString(
+				tt.data,
+			)
+
+			g.Expect(b).To(BeIdenticalTo(tt.want))
+		})
+	}
+}
+
+func TestLoadListFromString(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want []string
+	}{
+		{
+			name: "Load list from string",
+			data: "a,b,c",
+			want: []string{"c", "a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			b := LoadListFromString(
+				tt.data,
+			)
+
+			g.Expect(b).To(BeIdenticalTo(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
This introduces two new helper functions to represent list data as a comma separated string.