### PR TITLE
Fix local testing without $OPERATOR_TEMPLATES

### DIFF
--- a/modules/common/util/template_util_test.go
+++ b/modules/common/util/template_util_test.go
@@ -44,7 +44,7 @@ func TestGetTemplatesPath(t *testing.T) {
 	t.Run("Lower string", func(t *testing.T) {
 		g := NewWithT(t)
 
-		p := GetTemplatesPath()
+		p, _ := GetTemplatesPath()
 
 		g.Expect(p).To(BeIdenticalTo(templatePath))
 	})
@@ -93,7 +93,7 @@ func TestGetAllTemplates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			p := GetTemplatesPath()
+			p, _ := GetTemplatesPath()
 			g.Expect(p).To(BeADirectory())
 
 			templatesFiles := GetAllTemplates(p, tt.kind, string(tt.tmplType), tt.version)
@@ -201,7 +201,7 @@ func TestGetTemplateData(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			p := GetTemplatesPath()
+			p, _ := GetTemplatesPath()
 			g.Expect(p).To(BeADirectory())
 
 			templatesFiles, err := GetTemplateData(tt.tmpl)


### PR DESCRIPTION
Currently it does not work (probably since migrating these to common-lib modules). GetTemplatesPath() function signature has been changed. Looks like it's not called externally yet, hence there would be no impact.