### PR TITLE
Set InterfaceRequest to get an expected ifname in the pod

### DIFF
--- a/modules/common/networkattachment/networkattachment.go
+++ b/modules/common/networkattachment/networkattachment.go
@@ -56,8 +56,9 @@ func CreateNetworksAnnotation(namespace string, nads []string) (map[string]strin
 		netAnnotations = append(
 			netAnnotations,
 			networkv1.NetworkSelectionElement{
-				Name:      nad,
-				Namespace: namespace,
+				Name:             nad,
+				Namespace:        namespace,
+				InterfaceRequest: GetNetworkIFName(nad),
 			},
 		)
 	}
@@ -68,6 +69,15 @@ func CreateNetworksAnnotation(namespace string, nads []string) (map[string]strin
 	}
 
 	return map[string]string{networkv1.NetworkAttachmentAnnot: string(networks)}, nil
+}
+
+// GetNetworkIFName returns the interface name base on the NAD name
+// the interface name in Linux must not be longer then 15 chars.
+func GetNetworkIFName(nad string) string {
+	if len(nad) > 15 {
+		return nad[:15]
+	}
+	return nad
 }
 
 // GetNetworkStatusFromAnnotation returns NetworkStatus list with networking details the pods are attached to

--- a/modules/common/networkattachment/networkattachment_test.go
+++ b/modules/common/networkattachment/networkattachment_test.go
@@ -42,13 +42,13 @@ func TestCreateNetworksAnnotation(t *testing.T) {
 			name:      "Single network",
 			networks:  []string{"one"},
 			namespace: "foo",
-			want:      map[string]string{networkv1.NetworkAttachmentAnnot: "[{\"name\":\"one\",\"namespace\":\"foo\"}]"},
+			want:      map[string]string{networkv1.NetworkAttachmentAnnot: "[{\"name\":\"one\",\"namespace\":\"foo\",\"interface\":\"one\"}]"},
 		},
 		{
 			name:      "Multiple networks",
 			networks:  []string{"one", "two"},
 			namespace: "foo",
-			want:      map[string]string{networkv1.NetworkAttachmentAnnot: "[{\"name\":\"one\",\"namespace\":\"foo\"},{\"name\":\"two\",\"namespace\":\"foo\"}]"},
+			want:      map[string]string{networkv1.NetworkAttachmentAnnot: "[{\"name\":\"one\",\"namespace\":\"foo\",\"interface\":\"one\"},{\"name\":\"two\",\"namespace\":\"foo\",\"interface\":\"two\"}]"},
 		},
 	}
 
@@ -138,4 +138,34 @@ func TestGetNetworkStatusFromAnnotation(t *testing.T) {
 		})
 	}
 
+}
+
+func TestGetNetworkIFName(t *testing.T) {
+
+	tests := []struct {
+		name string
+		nad  string
+		want string
+	}{
+		{
+			name: "short NAD name",
+			nad:  "short",
+			want: "short",
+		},
+		{
+			name: "long NAD name",
+			nad:  "reallylongnadnamewithmorethan15chars",
+			want: "reallylongnadna",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			ifName := GetNetworkIFName(tt.nad)
+
+			g.Expect(ifName).To(BeEquivalentTo(tt.want))
+		})
+	}
 }


### PR DESCRIPTION
For some services its required to identify its IP on a given network specified via an NAD name. Since it is not guaranteed which interface is used for this network the network interface name can be requested via the NetworkAttachmentAnnot annotation.

GetNetworkIFName returns the interface name base on the NAD name the interface name in Linux must not be longer then 15 chars.