### PR TITLE
Fix omitempty + default value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ gowork:
 
 .PHONY: operator-lint
 operator-lint: gowork ## Runs operator-lint
-	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.1.0
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.3.0
 	for mod in $(shell find modules/ -maxdepth 1 -mindepth 1 -type d); do \
 		set -x ; \
 		if [ $$mod == "modules/archive" ]; then continue; fi ; \

--- a/modules/storage/ceph/types.go
+++ b/modules/storage/ceph/types.go
@@ -43,7 +43,7 @@ type Backend struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="CephUser"
 	// User set the Ceph cluster pool
-	User string `json:"cephUser,omitempty"`
+	User string `json:"cephUser"`
 	// +kubebuilder:validation:Optional
 	// Pools - Map of chosen names to spec definitions for the Ceph cluster
 	// pools


### PR DESCRIPTION
Having a CRD field with omitempty tag with a kubebuilder default value defined can cause unexpected behavior. See https://github.com/gibizer/operator-lint/blob/main/linters/crd/C003 for details.

So this patch remove the problematic definitions and bumps the operator-lint version to 0.3.0 that has a check to cover this.