### PR TITLE
support autogenerated route host

### DIFF
--- a/modules/common/route/types.go
+++ b/modules/common/route/types.go
@@ -36,4 +36,5 @@ type GenericRouteDetails struct {
 	Labels         map[string]string
 	ServiceName    string
 	TargetPortName string
+	FQDN           string
 }


### PR DESCRIPTION
this change adds support for setting the Host
field on a route object form the autogenerated value
on update.  When a route is created for the first time
the Host value was previously populated with the autogenerated
vlaue but that did not happen during update.

now we copy the autogenerated value from the status if
the Host field is not set and we have an ingress values
in the status.

This change also adds an optional FQDN field to the route
to allow use to not use the autogeneration in the future
if we want too. Currently this is unused.
