### PR TITLE
Add make gotidy target for renovate postupgradetask

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,15 @@ gowork:
 	for mod in $(shell find modules -maxdepth 1 -mindepth 1 -type d); do go work use $$mod; done
 	go work sync
 
+.PHONY: gotidy
+gotidy:
+	for mod in $(shell find modules/ -maxdepth 1 -mindepth 1 -type d); do \
+		set -x; \
+		pushd ./$$mod ; \
+		go mod tidy; \
+		popd; \
+	done
+
 .PHONY: operator-lint
 operator-lint: gowork ## Runs operator-lint
 	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.3.0

--- a/renovate.json
+++ b/renovate.json
@@ -37,8 +37,8 @@
     }
   ],
   "postUpgradeTasks": {
-    "commands": ["go mod tidy"],
-    "fileFilters": ["go.mod", "go.sum", "**/*.go", "**/*.yaml"],
+    "commands": ["make gotidy"],
+    "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],
     "executionMode": "update"
   }
 }


### PR DESCRIPTION
renovate runs go mod tidy as postupgradetask, which does not run in the directory of the sub dir. As there is no go.mod in the main repo dir, this go mod tidy fails. This adds a make gotidy target which loops through the sub module dirs and runs go mod tidy in there.

Depends-On: https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci/pull/74