### PR TITLE
Add ComponentSelector const and enhance VerifyNetworkStatusFromAnnotation

### DIFF
--- a/modules/common/const.go
+++ b/modules/common/const.go
@@ -20,6 +20,8 @@ package common
 const (
 	// AppSelector - used by operators to specify labels
 	AppSelector = "service"
+	// ComponentSelector - used by operators to specify labels for a sub component
+	ComponentSelector = "component"
 	// CustomServiceConfigFileName - file name used to add the service customizations
 	CustomServiceConfigFileName = "custom.conf"
 	// DebugCommand - Default debug command for pods

--- a/modules/common/networkattachment/networkattachment.go
+++ b/modules/common/networkattachment/networkattachment.go
@@ -97,18 +97,20 @@ func GetNetworkStatusFromAnnotation(annotations map[string]string) ([]networkv1.
 
 // VerifyNetworkStatusFromAnnotation - verifies if NetworkStatus annotation for the pods of a deployment,
 // pods identified via the service label selector, matches the passed in network attachments and the number of
-// per network IPs the ready count of the deployment. Return true if count matches with the list of IPs per network.
+// per network IPs the ready count of the deployment. Return true if count matches with the list of IPs per network,
+// no networkAttachments provided or expectedCount == 0
 func VerifyNetworkStatusFromAnnotation(
 	ctx context.Context,
 	helper *helper.Helper,
 	networkAttachments []string,
 	serviceLabels map[string]string,
 	readyCount int32,
+	expectedCount int32,
 ) (bool, map[string][]string, error) {
 
 	networkReady := true
 	networkAttachmentStatus := map[string][]string{}
-	if len(networkAttachments) > 0 {
+	if len(networkAttachments) > 0 && expectedCount > 0 {
 		podList, err := pod.GetPodListWithLabel(ctx, helper, helper.GetBeforeObject().GetNamespace(), serviceLabels)
 		if err != nil {
 			return false, networkAttachmentStatus, err


### PR DESCRIPTION
Adds expectedCount to VerifyNetworkStatusFromAnnotation
    
If there are networkAttachments specificed, but the replicas count of a deployment is 0, this func will return false. This adds an expectedCount parameter and if 0, the func returns true for networkReady.