### PR TITLE
Add constant for policy customization

### DIFF
--- a/modules/common/const.go
+++ b/modules/common/const.go
@@ -24,6 +24,8 @@ const (
 	ComponentSelector = "component"
 	// CustomServiceConfigFileName - file name used to add the service customizations
 	CustomServiceConfigFileName = "custom.conf"
+	// CustomPolicyFileName - file name used to add the policy rule customizations
+	CustomPolicyFileName = "custom.yaml"
 	// DebugCommand - Default debug command for pods
 	DebugCommand = "/usr/local/bin/kolla_set_configs && /bin/sleep infinity"
 	// InputHashName -Name of the hash of hashes of all resources used to indentify an input change


### PR DESCRIPTION
This introduces a constant which defines the name of customized policy file. The file will be created as /etc/<service>/policy.d/custom.yaml in each service.