### PR TITLE
Add ReconcileRbac function

### DIFF
--- a/modules/common/condition/conditions.go
+++ b/modules/common/condition/conditions.go
@@ -265,15 +265,24 @@ const (
 	// ServiceAccountCreatingMessage
 	ServiceAccountCreatingMessage = "ServiceAccount creation in progress"
 
+	// ServiceAccountReadyInitMessage
+	ServiceAccountReadyInitMessage = "ServiceAccount not created"
+
 	// RoleReadyErrorMessage
 	RoleReadyErrorMessage = "Role error occurred %s"
 
 	// RoleCreatingMessage
 	RoleCreatingMessage = "Role creation in progress"
 
+	// RoleReadyInitMessage
+	RoleReadyInitMessage = "Role not created"
+
 	// RoleBindingReadyErrorMessage
 	RoleBindingReadyErrorMessage = "RoleBinding error occurred %s"
 
 	// RoleBindingCreatingMessage
 	RoleBindingCreatingMessage = "RoleBinding creation in progress"
+
+	// RoleBindingReadyInitMessage
+	RoleBindingReadyInitMessage = "RoleBinding not created"
 )

--- a/modules/common/rbac/rbac.go
+++ b/modules/common/rbac/rbac.go
@@ -1,0 +1,130 @@
+package rbac
+
+import (
+	"context"
+	"time"
+
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	helper "github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	common_role "github.com/openstack-k8s-operators/lib-common/modules/common/role"
+	common_rolebinding "github.com/openstack-k8s-operators/lib-common/modules/common/rolebinding"
+	common_serviceaccount "github.com/openstack-k8s-operators/lib-common/modules/common/serviceaccount"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// Reconciler - interface for rbac reconcilers
+type Reconciler interface {
+	// RbacConditionsSet - set the conditions on the instance
+	RbacConditionsSet(c *condition.Condition)
+
+	// RbacNamespace - return a string representing the namespace
+	RbacNamespace() string
+
+	// RbacResourceName - name of the resource to be used in the rbac resources (service, role, rolebinding))
+	RbacResourceName() string
+}
+
+// ReconcileRbac - configures the serviceaccount, role, and role binding for the Reconciler instance
+func ReconcileRbac(ctx context.Context, h *helper.Helper, instance Reconciler, rules []rbacv1.PolicyRule) (ctrl.Result, error) {
+
+	// ServiceAccount
+	sa := common_serviceaccount.NewServiceAccount(
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instance.RbacResourceName(),
+				Namespace: instance.RbacNamespace(),
+			},
+		},
+		time.Duration(10),
+	)
+	saResult, err := sa.CreateOrPatch(ctx, h)
+	if err != nil {
+		instance.RbacConditionsSet(condition.FalseCondition(
+			condition.ServiceAccountReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.ServiceAccountReadyErrorMessage,
+			err.Error()))
+		return saResult, err
+	} else if (saResult != ctrl.Result{}) {
+		instance.RbacConditionsSet(condition.FalseCondition(
+			condition.ServiceAccountReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.ServiceAccountCreatingMessage))
+		return saResult, nil
+	}
+
+	// Role
+	role := common_role.NewRole(
+		&rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instance.RbacResourceName() + "-role",
+				Namespace: instance.RbacNamespace(),
+			},
+			Rules: rules,
+		},
+		time.Duration(10),
+	)
+	roleResult, err := role.CreateOrPatch(ctx, h)
+	if err != nil {
+		instance.RbacConditionsSet(condition.FalseCondition(
+			condition.RoleReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.RoleReadyErrorMessage,
+			err.Error()))
+		return roleResult, err
+	} else if (roleResult != ctrl.Result{}) {
+		instance.RbacConditionsSet(condition.FalseCondition(
+			condition.RoleReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.RoleCreatingMessage))
+		return roleResult, nil
+	}
+
+	// RoleBinding
+	rolebinding := common_rolebinding.NewRoleBinding(
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instance.RbacResourceName() + "-rolebinding",
+				Namespace: instance.RbacNamespace(),
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     instance.RbacResourceName() + "-role",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      instance.RbacResourceName(),
+					Namespace: instance.RbacNamespace(),
+				},
+			},
+		},
+		time.Duration(10),
+	)
+	roleBindingResult, err := rolebinding.CreateOrPatch(ctx, h)
+	if err != nil {
+		instance.RbacConditionsSet(condition.FalseCondition(
+			condition.RoleBindingReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.RoleBindingReadyErrorMessage,
+			err.Error()))
+		return roleBindingResult, err
+	} else if (roleBindingResult != ctrl.Result{}) {
+		instance.RbacConditionsSet(condition.FalseCondition(
+			condition.RoleBindingReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.RoleBindingCreatingMessage))
+		return roleBindingResult, nil
+	}
+	return ctrl.Result{}, nil
+}


### PR DESCRIPTION
This function will act as the primary means to help reconcile common rbac resources for serviceaccounts, roles, and rolebindings.

Individual operators can define functions for the rbac.Reconciler interface within their CRD reconcilers and then make a simple call to reconcile all these resources in the controller like:

	rbacRules := []rbacv1.PolicyRule{
		{
			APIGroups: []string{""},
			Resources: []string{"pods"},
			Verbs:     []string{"get", "list", "watch"},
		},
	}
	rbacResult, err := common_rbac.ReconcileRbac(ctx, h, instance, rbacRules)
	if err != nil {
		return rbacResult, err
	} else if (rbacResult != ctrl.Result{}) {
		return rbacResult, nil
	}