### PR TITLE
Job test with envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,9 +101,9 @@ govet: get-ci-tools
 
 # Run go test via ci-tools script against code
 .PHONY: gotest
-gotest: get-ci-tools
+gotest: get-ci-tools envtest
 	for mod in $(shell find modules/ -maxdepth 1 -mindepth 1 -type d); do \
-		GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/gotest.sh ./$$mod || exit 1 ; \
+		KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/gotest.sh ./$$mod || exit 1 ; \
 	done
 
 # Run golangci-lint test via ci-tools script against code

--- a/modules/archive/go.mod
+++ b/modules/archive/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/onsi/ginkgo/v2 v2.9.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	golang.org/x/net v0.9.0 // indirect

--- a/modules/archive/go.mod
+++ b/modules/archive/go.mod
@@ -29,12 +29,12 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect
 	golang.org/x/sys v0.7.0 // indirect

--- a/modules/archive/go.sum
+++ b/modules/archive/go.sum
@@ -106,7 +106,6 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
-github.com/onsi/ginkgo/v2 v2.9.2/go.mod h1:WHcJJG2dIlcCqVfBAwUCrJxSPFb6v4azBwgxeMeDuts=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/modules/archive/go.sum
+++ b/modules/archive/go.sum
@@ -91,6 +91,7 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -107,6 +108,7 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/modules/common/go.mod
+++ b/modules/common/go.mod
@@ -5,9 +5,11 @@ go 1.19
 require (
 	github.com/go-logr/logr v1.2.4
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
+	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.6
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/pkg/errors v0.9.1
+	go.uber.org/zap v1.24.0
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
 	k8s.io/client-go v0.26.3
@@ -22,9 +24,11 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.1 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
@@ -55,6 +59,7 @@ require (
 	golang.org/x/term v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/tools v0.7.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/modules/common/go.mod
+++ b/modules/common/go.mod
@@ -4,10 +4,12 @@ go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.4
+	github.com/google/uuid v1.3.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.6
 	github.com/openshift/api v3.9.0+incompatible
+	github.com/openstack-k8s-operators/lib-common/modules/test v0.0.0-20230427065458-ec1b923df88c
 	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.24.0
 	k8s.io/api v0.26.3
@@ -36,11 +38,9 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect; indirect // indirect // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -50,6 +50,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
@@ -75,3 +76,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/openstack-k8s-operators/lib-common/modules/test => ../test

--- a/modules/common/go.sum
+++ b/modules/common/go.sum
@@ -40,6 +40,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -91,9 +93,11 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/zapr v1.2.3 h1:a9vnzlIBPQBBkeaR9IuMUfmVOrQlkoC4YfPoFkX3T7A=
+github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
 github.com/go-openapi/jsonpointer v0.19.6 h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn38N2ZdrE=
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
 github.com/go-openapi/jsonreference v0.20.1 h1:FBLnyygC4/IZZr893oiomc9XaghoveYTrLC1F86HID8=
@@ -102,6 +106,7 @@ github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -223,8 +228,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
+github.com/onsi/ginkgo/v2 v2.9.2/go.mod h1:WHcJJG2dIlcCqVfBAwUCrJxSPFb6v4azBwgxeMeDuts=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
 github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
@@ -281,6 +286,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -302,10 +308,14 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
+go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
+go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
+go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -475,6 +485,7 @@ golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -503,6 +514,7 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
+golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/modules/common/go.sum
+++ b/modules/common/go.sum
@@ -207,7 +207,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
-github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -234,7 +233,6 @@ github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
 github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
 github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
-github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/modules/common/test/functional/job_test.go
+++ b/modules/common/test/functional/job_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package functional
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Job test", func() {
+
+	When("DoJob is called", func() {
+		It("runs a Job", func() {
+			Expect(true).To(BeFalse())
+		})
+	})
+})

--- a/modules/common/test/functional/job_test.go
+++ b/modules/common/test/functional/job_test.go
@@ -16,15 +16,297 @@ limitations under the License.
 package functional
 
 import (
+	"errors"
+
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/job"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("Job test", func() {
+const (
+	noHash   = ""
+	preserve = true
+)
 
-	When("DoJob is called", func() {
-		It("runs a Job", func() {
-			Expect(true).To(BeFalse())
-		})
+func getExampleJob(namespace string) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: namespace,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+					Containers: []corev1.Container{
+						{
+							Name: "test-job-pod",
+							Command: []string{
+								"/bin/bash",
+							},
+							Image: "test-container-image",
+						},
+					},
+				},
+			},
+		},
+	}
+
+}
+
+var _ = Describe("job.Job", func() {
+	var namespace string
+
+	BeforeEach(func() {
+		// NOTE(gibi): We need to create a unique namespace for each test run
+		// as namespaces cannot be deleted in a locally running envtest. See
+		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
+		namespace = uuid.New().String()
+		th.CreateNamespace(namespace)
+		// We still request the delete of the Namespace to properly cleanup if
+		// we run the test in an existing cluster.
+		DeferCleanup(th.DeleteNamespace, namespace)
+
 	})
+
+	It("defaults the TTL if not provided", func() {
+		exampleJob := getExampleJob(namespace)
+		j := job.NewJob(exampleJob, "test-job", !preserve, timeout, noHash)
+
+		_, err := j.DoJob(ctx, h)
+
+		Expect(err).ShouldNot(HaveOccurred())
+		gotJob, err := job.GetJobWithName(ctx, h, exampleJob.Name, namespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		// job.defaultTTL is 600
+		Expect(*gotJob.Spec.TTLSecondsAfterFinished).To(Equal(int32(600)))
+	})
+
+	It("keeps the requested TTL", func() {
+		exampleJob := getExampleJob(namespace)
+		var ttl int32 = 13
+		exampleJob.Spec.TTLSecondsAfterFinished = &ttl
+		j := job.NewJob(exampleJob, "test-job", !preserve, timeout, noHash)
+
+		_, err := j.DoJob(ctx, h)
+
+		Expect(err).ShouldNot(HaveOccurred())
+		gotJob, err := job.GetJobWithName(ctx, h, exampleJob.Name, namespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*gotJob.Spec.TTLSecondsAfterFinished).To(Equal(ttl))
+	})
+
+	It("sets the TTL to infinite if preserve is requested", func() {
+		exampleJob := getExampleJob(namespace)
+		var ttl int32 = 13
+		exampleJob.Spec.TTLSecondsAfterFinished = &ttl
+		j := job.NewJob(exampleJob, "test-job", preserve, timeout, noHash)
+
+		_, err := j.DoJob(ctx, h)
+
+		Expect(err).ShouldNot(HaveOccurred())
+		gotJob, err := job.GetJobWithName(ctx, h, exampleJob.Name, namespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		// TTL=nil means TTL is infinite
+		Expect(gotJob.Spec.TTLSecondsAfterFinished).To(BeNil())
+	})
+
+	It("runs the job if it has a new hash and the job does not exists", func() {
+		exampleJob := getExampleJob(namespace)
+		j := job.NewJob(exampleJob, "test-job", !preserve, timeout, noHash)
+
+		result, err := j.DoJob(ctx, h)
+
+		// The caller is asked to requeue as the job is not finished yet
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{RequeueAfter: timeout}))
+
+		// a k8s Job is created in with an controller reference
+		k8sJob := th.GetJob(th.GetName(exampleJob))
+		Expect(k8sJob.GetOwnerReferences()).To(HaveLen(1))
+		Expect(k8sJob.GetOwnerReferences()[0]).To(HaveField("Name", h.GetBeforeObject().GetName()))
+		t := true
+		Expect(k8sJob.GetOwnerReferences()[0]).To(HaveField("Controller", &t))
+
+		// The passed in hash, that was empty, is different from the hash of the
+		// job
+		Expect(j.HasChanged()).To(BeTrue())
+		Expect(j.GetHash()).NotTo(Equal(noHash))
+
+		// Simulate that the Job succeeded
+		th.SimulateJobSuccess(th.GetName(exampleJob))
+
+		result, err = j.DoJob(ctx, h)
+
+		// The empty result signals the caller that the job is finished
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+		// the hash is still different from the empty hash
+		Expect(j.HasChanged()).To(BeTrue())
+		Expect(j.GetHash()).NotTo(Equal(noHash))
+	})
+
+	It("re-runs the job if its hash differs and the previous job exists", func() {
+		exampleJob := getExampleJob(namespace)
+		j := job.NewJob(exampleJob, "test-job", !preserve, timeout, noHash)
+
+		// runs the job to completion
+		_, err := j.DoJob(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+		th.SimulateJobSuccess(th.GetName(exampleJob))
+		result, err := j.DoJob(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		// store the job's hash after it is finished
+		storedHash := j.GetHash()
+		Expect(storedHash).NotTo(BeEmpty())
+
+		k8sJobUID := th.GetJob(th.GetName(exampleJob)).UID
+
+		// requests a new job as the input of the job is changed, e.g. the image of
+		// the job is changed
+		newJob := getExampleJob(namespace)
+		newJob.Spec.Template.Spec.Containers[0].Image = "new-image"
+		j = job.NewJob(newJob, "test-job", !preserve, timeout, noHash)
+		result, err = j.DoJob(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+		// BUG
+		// We expect a new job being created as the existing one has a different
+		// hash than the newly requested one and therefore DoJob should request a
+		// requeue to wait for the Job to finish.
+		//
+		// g.Expect(result).To(Equal(ctrl.Result{RequeueAfter: timeout}))
+		//
+		// But instead the lib-common code sees the previous finished k8s job
+		// and returns that the job is succeeded, but now with the new hash
+		// without creating a new job.
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		Expect(j.HasChanged()).To(BeTrue())
+		Expect(j.GetHash()).NotTo(Equal(storedHash))
+
+		// This proves that there was no new k8s Job created with the same
+		// name as the UID is the same as the first job.
+		Expect(th.GetJob(th.GetName(newJob)).UID).To(Equal(k8sJobUID))
+	})
+
+	It("re-runs the job if its hash differs and the previous already deleted", func() {
+		exampleJob := getExampleJob(namespace)
+		j := job.NewJob(exampleJob, "test-job", !preserve, timeout, noHash)
+
+		// runs the job to completion
+		_, err := j.DoJob(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+		th.SimulateJobSuccess(th.GetName(exampleJob))
+		result, err := j.DoJob(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		// store the job's hash after it is finished
+		storedHash := j.GetHash()
+		Expect(storedHash).NotTo(BeEmpty())
+
+		k8sJobUID := th.GetJob(th.GetName(exampleJob)).UID
+
+		// simulate that the TTL of the job is expired and therefore the job is
+		// deleted
+		// need background propagation policy otherwise the Job remains
+		// in orphan state
+		background := metav1.DeletePropagationBackground
+		th.DeleteInstance(exampleJob, &client.DeleteOptions{PropagationPolicy: &background})
+
+		// requests a new job as the input of the job is changed, e.g. the image of
+		// the job is changed
+		newJob := getExampleJob(namespace)
+		newJob.Spec.Template.Spec.Containers[0].Image = "new-image"
+		j = job.NewJob(newJob, "test-job", !preserve, timeout, noHash)
+		result, err = j.DoJob(ctx, h)
+		// we expect that a new job is created and the client is requested to
+		// requeue while waiting for the job to finish
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{RequeueAfter: timeout}))
+
+		Expect(j.HasChanged()).To(BeTrue())
+		Expect(j.GetHash()).NotTo(Equal(storedHash))
+
+		Expect(th.GetJob(th.GetName(newJob)).UID).NotTo(Equal(k8sJobUID))
+	})
+
+	It("reports failure if the job failed", func() {
+		exampleJob := getExampleJob(namespace)
+		j := job.NewJob(exampleJob, "test-job", !preserve, timeout, noHash)
+
+		result, err := j.DoJob(ctx, h)
+
+		// The caller is asked to requeue as the job is not finished yet
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{RequeueAfter: timeout}))
+
+		// a k8s Job is created in with an controller reference
+		th.GetJob(th.GetName(exampleJob))
+
+		// Simulate that the Job succeeded
+		th.SimulateJobFailure(th.GetName(exampleJob))
+
+		_, err = j.DoJob(ctx, h)
+
+		Expect(err).Should(HaveOccurred())
+		var statusErr *k8s_errors.StatusError
+		Expect(errors.As(err, &statusErr)).To(BeTrue())
+		Expect(statusErr.Status().Message).To(ContainSubstring("Job Failed"))
+	})
+
+	It("reports error if the job definition is changed while the job still running", func() {
+		exampleJob := getExampleJob(namespace)
+		j := job.NewJob(exampleJob, "test-job", !preserve, timeout, noHash)
+
+		result, err := j.DoJob(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).NotTo(Equal(ctrl.Result{}))
+		oldHash := j.GetHash()
+
+		newJob := getExampleJob(namespace)
+		newJob.Spec.Template.Spec.Containers[0].Image = "new-image"
+
+		j = job.NewJob(newJob, "test-job", !preserve, timeout, noHash)
+		result, err = j.DoJob(ctx, h)
+		// BUG: we should report an error to the caller to indicate that
+		// the job cannot be changed as it is still running
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).NotTo(Equal(ctrl.Result{}))
+
+		// Assert that the running job is not changed so it still has the
+		// image of the original request
+		k8sJob := th.GetJob(th.GetName(newJob))
+		Expect(k8sJob.Spec.Template.Spec.Containers[0].Image).To(
+			Equal(exampleJob.Spec.Template.Spec.Containers[0].Image))
+
+		// Simulate that the original Job succeeds
+		th.SimulateJobSuccess(th.GetName(exampleJob))
+
+		// We expect that if DoJob is called with the new job now then a
+		// new k8s job is created to re-run the job
+		// BUG: but instead we report success for the old job content
+		// with the new jobs hash
+		result, err = j.DoJob(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+		// the job content is not changed
+		k8sJob = th.GetJob(th.GetName(newJob))
+		Expect(k8sJob.Spec.Template.Spec.Containers[0].Image).To(
+			Equal(exampleJob.Spec.Template.Spec.Containers[0].Image))
+		// but the reported job has does
+		Expect(j.GetHash()).NotTo(Equal(oldHash))
+	})
+
 })

--- a/modules/common/test/functional/suite_test.go
+++ b/modules/common/test/functional/suite_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package functional
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	batchv1 "k8s.io/api/batch/v1"
+	//+kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+	logger    logr.Logger
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "common module suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), func(o *zap.Options) {
+		o.Development = true
+		o.TimeEncoder = zapcore.ISO8601TimeEncoder
+	}))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		ErrorIfCRDPathMissing: true,
+	}
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = batchv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	//+kubebuilder:scaffold:scheme
+
+	logger = ctrl.Log.WithName("---Test---")
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	go func() {
+		defer GinkgoRecover()
+	}()
+
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/modules/database/go.mod
+++ b/modules/database/go.mod
@@ -9,7 +9,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.14.6
 )
 
-require github.com/rogpeppe/go-internal v1.9.0 // indirect
+require github.com/kr/pretty v0.3.1 // indirect
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/modules/database/go.mod
+++ b/modules/database/go.mod
@@ -9,6 +9,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.14.6
 )
 
+require github.com/rogpeppe/go-internal v1.9.0 // indirect
+
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
@@ -35,13 +37,11 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/onsi/ginkgo/v2 v2.9.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect

--- a/modules/database/go.sum
+++ b/modules/database/go.sum
@@ -197,6 +197,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -221,6 +222,7 @@ github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230428102546-5d2d648e367e h1:hd6vDQcn8rMiUcxgcByAj32DGEXQ6X9MzlE7X15Di30=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230428102546-5d2d648e367e/go.mod h1:OJbXy49Ktmyt13xBzdbHzYUOipKr17kOKUOFa/vB/ls=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/modules/database/go.sum
+++ b/modules/database/go.sum
@@ -218,7 +218,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
-github.com/onsi/ginkgo/v2 v2.9.2/go.mod h1:WHcJJG2dIlcCqVfBAwUCrJxSPFb6v4azBwgxeMeDuts=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230428102546-5d2d648e367e h1:hd6vDQcn8rMiUcxgcByAj32DGEXQ6X9MzlE7X15Di30=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230428102546-5d2d648e367e/go.mod h1:OJbXy49Ktmyt13xBzdbHzYUOipKr17kOKUOFa/vB/ls=

--- a/modules/openstack/go.mod
+++ b/modules/openstack/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/onsi/ginkgo/v2 v2.9.2 // indirect
 	github.com/openshift/api v3.9.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect

--- a/modules/openstack/go.mod
+++ b/modules/openstack/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230427065458-ec1b923df88c
 )
 
+require github.com/kr/pretty v0.3.1 // indirect
+
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
@@ -39,7 +41,6 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect

--- a/modules/openstack/go.sum
+++ b/modules/openstack/go.sum
@@ -220,7 +220,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
-github.com/onsi/ginkgo/v2 v2.9.2/go.mod h1:WHcJJG2dIlcCqVfBAwUCrJxSPFb6v4azBwgxeMeDuts=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
 github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=

--- a/modules/openstack/go.sum
+++ b/modules/openstack/go.sum
@@ -199,6 +199,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -223,6 +224,7 @@ github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
 github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/modules/test/helpers/common.go
+++ b/modules/test/helpers/common.go
@@ -104,3 +104,8 @@ func (tc *TestHelper) CreateUnstructured(rawObj map[string]interface{}) *unstruc
 
 	return unstructuredObj
 }
+
+// GetName -
+func (tc *TestHelper) GetName(obj client.Object) types.NamespacedName {
+	return types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+}

--- a/modules/test/helpers/instance.go
+++ b/modules/test/helpers/instance.go
@@ -22,9 +22,14 @@ import (
 )
 
 // DeleteInstance -
-func (tc *TestHelper) DeleteInstance(instance client.Object) {
+func (tc *TestHelper) DeleteInstance(instance client.Object, opts ...client.DeleteOption) {
 	// We have to wait for the controller to fully delete the instance
-	tc.Logger.Info("Deleting", "Name", instance.GetName(), "Namespace", instance.GetNamespace(), "Kind", instance.GetObjectKind().GroupVersionKind().Kind)
+	tc.Logger.Info(
+		"Deleting", "Name", instance.GetName(),
+		"Namespace", instance.GetNamespace(),
+		"Kind", instance.GetObjectKind(),
+	)
+
 	gomega.Eventually(func(g gomega.Gomega) {
 		name := types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 		err := tc.K8sClient.Get(tc.Ctx, name, instance)
@@ -34,9 +39,15 @@ func (tc *TestHelper) DeleteInstance(instance client.Object) {
 		}
 		g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-		g.Expect(tc.K8sClient.Delete(tc.Ctx, instance)).Should(gomega.Succeed())
+		g.Expect(tc.K8sClient.Delete(tc.Ctx, instance, opts...)).Should(gomega.Succeed())
 
 		err = tc.K8sClient.Get(tc.Ctx, name, instance)
 		g.Expect(k8s_errors.IsNotFound(err)).To(gomega.BeTrue())
 	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
+
+	tc.Logger.Info(
+		"Deleted", "Name", instance.GetName(),
+		"Namespace", instance.GetNamespace(),
+		"Kind", instance.GetObjectKind().GroupVersionKind().Kind,
+	)
 }

--- a/modules/test/helpers/job.go
+++ b/modules/test/helpers/job.go
@@ -50,6 +50,8 @@ func (tc *TestHelper) SimulateJobFailure(name types.NamespacedName) {
 	job.Status.Failed = 1
 	job.Status.Active = 0
 	gomega.Expect(tc.K8sClient.Status().Update(tc.Ctx, job)).To(gomega.Succeed())
+
+	tc.Logger.Info("Simulated Job failure", "on", name)
 }
 
 // SimulateJobSuccess -
@@ -65,4 +67,6 @@ func (tc *TestHelper) SimulateJobSuccess(name types.NamespacedName) {
 	job.Status.Succeeded = 1
 	job.Status.Active = 0
 	gomega.Expect(tc.K8sClient.Status().Update(tc.Ctx, job)).To(gomega.Succeed())
+
+	tc.Logger.Info("Simulated Job success", "on", name)
 }


### PR DESCRIPTION
These tests uses envtest for the external dependencies
There are possible alternatives for this:
* golang unit test with a handrolled mock for the external dependencies
  see https://github.com/openstack-k8s-operators/lib-common/pull/246
* controllerutils fake client (DEPRECATED) https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client/fake
* k8s fake client https://pkg.go.dev/k8s.io/client-go/kubernetes/fake
  (I'm not sure if it can be make compatible with controller-runtime)
* using mock libs / generators

Depends-on: https://github.com/openstack-k8s-operators/lib-common/pull/252