### PR TITLE
Update pre-commit and golangci-lint setting

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -20,28 +20,9 @@ jobs:
       - name: Run gotest.sh
         run: make gotest
 
-  golangci:
-    name: github (golangci)
+  pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.19.x
-      - name: Checkout project code
-        uses: actions/checkout@v2
-      - name: Run golangci lint
-        run: make golangci
-
-  operator-lint:
-    name: operator-lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.19.x
-      - name: Checkout project code
-        uses: actions/checkout@v2
-      - name: Run operator-lint
-        run: make operator-lint
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,6 +4,7 @@ linters:
   enable:
     - errorlint
     - revive
+    - ginkgolinter
     - gofmt
     - govet
 linters-settings:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,14 +7,18 @@ repos:
       entry: make
       args: ['operator-lint']
       pass_filenames: false
-
-- repo: https://github.com/dnephin/pre-commit-golang
-  rev: v0.5.1
-  hooks:
-    - id: go-fmt
-      exclude: ^vendor
-    - id: go-mod-tidy
-    - id: go-lint
+    - id: make-tidy
+      name: make-tidy
+      language: system
+      entry: make
+      args: ['tidy']
+      pass_filenames: false
+    - id: make-golangci-lint
+      name: make-golangci-lint
+      language: system
+      entry: make
+      args: ['golangci']
+      pass_filenames: false
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0

--- a/modules/common/annotations/network_test.go
+++ b/modules/common/annotations/network_test.go
@@ -55,7 +55,7 @@ func TestGetNADAnnotation(t *testing.T) {
 			g := NewWithT(t)
 
 			networkAnnotation, err := GetNADAnnotation(tt.namespace, tt.networks)
-			g.Expect(err).To(BeNil())
+			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(networkAnnotation).To(HaveLen(len(tt.want)))
 			g.Expect(networkAnnotation).To(BeEquivalentTo(tt.want))
 		})

--- a/modules/common/helper/helper_test.go
+++ b/modules/common/helper/helper_test.go
@@ -47,7 +47,7 @@ func TestToUnstructured(t *testing.T) {
 
 		// Change a spec field and validate that it stays the same in the incoming object.
 		g.Expect(unstructured.SetNestedField(newObj.Object, "false", "spec", "paused")).To(Succeed())
-		g.Expect(obj.Spec.Paused).To(Equal(true))
+		g.Expect(obj.Spec.Paused).To(BeTrue())
 	})
 
 	t.Run("with an unstructured object", func(t *testing.T) {

--- a/modules/common/networkattachment/networkattachment_test.go
+++ b/modules/common/networkattachment/networkattachment_test.go
@@ -57,7 +57,7 @@ func TestCreateNetworksAnnotation(t *testing.T) {
 			g := NewWithT(t)
 
 			networkAnnotation, err := CreateNetworksAnnotation(tt.namespace, tt.networks)
-			g.Expect(err).To(BeNil())
+			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(networkAnnotation).To(HaveLen(len(tt.want)))
 			g.Expect(networkAnnotation).To(BeEquivalentTo(tt.want))
 		})
@@ -132,7 +132,7 @@ func TestGetNetworkStatusFromAnnotation(t *testing.T) {
 			g := NewWithT(t)
 
 			networkStatus, err := GetNetworkStatusFromAnnotation(tt.annotations)
-			g.Expect(err).To(BeNil())
+			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(networkStatus).To(HaveLen(len(tt.want)))
 			g.Expect(networkStatus).To(BeEquivalentTo(tt.want))
 		})

--- a/modules/common/util/funcs_test.go
+++ b/modules/common/util/funcs_test.go
@@ -124,9 +124,9 @@ func TestIsJSON(t *testing.T) {
 
 			err := IsJSON(tt.data)
 			if tt.error {
-				g.Expect(err).ToNot(BeNil())
+				g.Expect(err).To(HaveOccurred())
 			} else {
-				g.Expect(err).To(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}

--- a/modules/common/util/hash_test.go
+++ b/modules/common/util/hash_test.go
@@ -43,7 +43,7 @@ func TestObjectHash(t *testing.T) {
 			g := NewWithT(t)
 
 			hash, err := ObjectHash(tt.data)
-			g.Expect(err).To(BeNil())
+			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(hash).To(BeIdenticalTo(tt.want))
 		})
@@ -134,7 +134,7 @@ func TestHashOfInputHashes(t *testing.T) {
 			g := NewWithT(t)
 
 			hash, err := HashOfInputHashes(tt.envs)
-			g.Expect(err).To(BeNil())
+			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(hash).To(BeEquivalentTo(tt.want))
 		})
 	}

--- a/modules/common/util/template_util_test.go
+++ b/modules/common/util/template_util_test.go
@@ -249,9 +249,9 @@ func TestGetTemplateData(t *testing.T) {
 			templatesFiles, err := GetTemplateData(tt.tmpl)
 
 			if tt.error {
-				g.Expect(err).ToNot(BeNil())
+				g.Expect(err).To(HaveOccurred())
 			} else {
-				g.Expect(err).To(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 
 				g.Expect(templatesFiles).To(HaveLen(len(tt.want)))
 				for k, v := range tt.want {

--- a/modules/storage/ceph/util_test.go
+++ b/modules/storage/ceph/util_test.go
@@ -1,8 +1,9 @@
 package ceph
 
 import (
-	. "github.com/onsi/gomega"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestValidateMons(t *testing.T) {
@@ -10,19 +11,19 @@ func TestValidateMons(t *testing.T) {
 	t.Run("Empty string", func(t *testing.T) {
 		g := NewWithT(t)
 		m := ValidateMons("")
-		g.Expect(m).To(Equal(false))
+		g.Expect(m).To(BeFalse())
 	})
 	// Valid use case
 	t.Run("Validate Mons", func(t *testing.T) {
 		g := NewWithT(t)
 		m := ValidateMons("192.168.2.2,192.168.2.3, 192.168.2.4")
-		g.Expect(m).To(Equal(true))
+		g.Expect(m).To(BeTrue())
 	})
 
 	t.Run("Validate (Wrong) Mons", func(t *testing.T) {
 		// Input with a wrong IP address
 		g := NewWithT(t)
 		m := ValidateMons("192.168.2.2,192.168.2.3,192.168.2")
-		g.Expect(m).To(Equal(false))
+		g.Expect(m).To(BeFalse())
 	})
 }

--- a/modules/test/go.mod
+++ b/modules/test/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.24.1
 	github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230210143210-6e3aad14c3aa
 	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230113085458-cccfbcaf9f22
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230207162833-94c25ed85b4c
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230425053514-21f91c966010
 	golang.org/x/mod v0.8.0
 	k8s.io/api v0.26.2
 	k8s.io/apimachinery v0.26.2
@@ -54,7 +54,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230418061659-72d5158a8337
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230428102546-5d2d648e367e
 	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect

--- a/modules/test/go.sum
+++ b/modules/test/go.sum
@@ -226,12 +226,12 @@ github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230210143210-6e3
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230210143210-6e3aad14c3aa/go.mod h1:5kG0Ct412tO3fNkZ5b3/BwwSsV7LkSNfOB/apUlbMJI=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230113085458-cccfbcaf9f22 h1:zBjWHy8LqQ2G5rLPk+lPbqJKRBUOjrky6e5Y/QS61lg=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230113085458-cccfbcaf9f22/go.mod h1:3trfHFwIy+GvzkUVPzSofEdahCDyST3fWlKgloiI8cs=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230207162833-94c25ed85b4c h1:fGV+R0B/JbXw01wV7GwiegAKbzUe1gxeKdawiS5AAJQ=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230207162833-94c25ed85b4c/go.mod h1:qV9OlokZRpqbHI3lmeN5EOmIKynWphw6GPl3zP9KOGM=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230425053514-21f91c966010 h1:wBdbDUd90qcecbpVCpyBsBVPz14aBDAzE77tL3/xtkE=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230425053514-21f91c966010/go.mod h1:jDSW6narykfQyBtGTx6Kb6ZfTZgfzlyn/hF2zFs6sAs=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220915080953-f73a201a1da6 h1:MVNEHyqD0ZdO9jiyUSKw5M2T9Lc4l4Wx1pdC2/BSJ5Y=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220915080953-f73a201a1da6/go.mod h1:YsqouRH8DoZAjFaxcIErspk59BcwXtVjPxK/yV17Wrc=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230418061659-72d5158a8337 h1:aAsHGEf1C20+UzIbHKRYOq3aeEVuELtWr96VRooHpyg=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230418061659-72d5158a8337/go.mod h1:dvvbNaiMOGOgI+JfbM6lvZbRoiqOULAbIlbW5KEuvF0=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230428102546-5d2d648e367e h1:hd6vDQcn8rMiUcxgcByAj32DGEXQ6X9MzlE7X15Di30=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230428102546-5d2d648e367e/go.mod h1:OJbXy49Ktmyt13xBzdbHzYUOipKr17kOKUOFa/vB/ls=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/modules/test/helpers/database.go
+++ b/modules/test/helpers/database.go
@@ -58,7 +58,7 @@ func (tc *TestHelper) DeleteDBService(name types.NamespacedName) {
 		if k8s_errors.IsNotFound(err) {
 			return
 		}
-		g.Expect(err).Should(t.BeNil())
+		g.Expect(err).NotTo(t.HaveOccurred())
 
 		g.Expect(tc.k8sClient.Delete(tc.ctx, service)).Should(t.Succeed())
 

--- a/modules/test/helpers/keystone.go
+++ b/modules/test/helpers/keystone.go
@@ -62,7 +62,7 @@ func (tc *TestHelper) DeleteKeystoneAPI(name types.NamespacedName) {
 		if k8s_errors.IsNotFound(err) {
 			return
 		}
-		g.Expect(err).Should(t.BeNil())
+		g.Expect(err).NotTo(t.HaveOccurred())
 
 		g.Expect(tc.k8sClient.Delete(tc.ctx, keystone)).Should(t.Succeed())
 


### PR DESCRIPTION
Added golangci-lint execution in pre-commit and updated enabled linters. Fixed the ginkgolinter findings.

Also added a github action to run pre-commit. Eventually we want to run prow CI on lib-common but that needs more prep work.