### PR TITLE
[Job]Support re-running the job while previous job still exists

### DIFF
--- a/modules/common/job/types.go
+++ b/modules/common/job/types.go
@@ -23,16 +23,18 @@ import (
 )
 
 const (
-	defaultTTL int32 = 10 * 60 // 10 minutes
+	hashAnnotationName       = "hash"
+	defaultTTL         int32 = 10 * 60 // 10 minutes
 )
 
 // Job -
 type Job struct {
-	job        *batchv1.Job
-	jobType    string
-	preserve   bool
-	timeout    time.Duration
-	beforeHash string
-	hash       string
-	changed    bool
+	expectedJob *batchv1.Job
+	actualJob   *batchv1.Job
+	jobType     string
+	preserve    bool
+	timeout     time.Duration
+	beforeHash  string
+	hash        string
+	changed     bool
 }


### PR DESCRIPTION
The job handling logic is changed to allow re-running the job if the
hash of the job changed while the previous job is still exists.

If the old job still not finished when DoJob is called with a new job
then the caller is requested to wait by returning requeue result
until the old job is finished (either succeeded or failed).

If the old job already finished when DoJob is called with a new job
then then the old job is deleted and the caller is requested to requeue.
So that when DoJob is called after this requeue the normal code path can
be taken, and a new job can be created as no job exists.

To be able to detect the if the hash of the job is changed while the old
job is still running the hash of the job is stored as an annotation on
the k8s job object. This way DoJob can compare the hash of the running
job and the hash of the expected job.

The hash of the job is modified to only consider the Job.Spec.Template
part. As fields outside of the Template (e.g. TTL) are not defining what
to be run, but just how to run it. This way TTL can he changed on the
job any time without affecting its hash.

Depends-on: https://github.com/openstack-k8s-operators/lib-common/pull/247