### PR TITLE
[test-operators]Simulate internal endpoint for Keystone

### DIFF
--- a/modules/test-operators/helpers/keystone.go
+++ b/modules/test-operators/helpers/keystone.go
@@ -43,7 +43,10 @@ func (tc *TestHelper) CreateKeystoneAPI(namespace string) types.NamespacedName {
 	// the Status field needs to be written via a separate client
 	keystone = tc.GetKeystoneAPI(name)
 	keystone.Status = keystonev1.KeystoneAPIStatus{
-		APIEndpoints: map[string]string{"public": "http://keystone-public-openstack.testing"},
+		APIEndpoints: map[string]string{
+			"public":   "http://keystone-public-openstack.testing",
+			"internal": "http://keystone-internal.openstack.svc:5000",
+		},
 	}
 	t.Expect(tc.K8sClient.Status().Update(tc.Ctx, keystone.DeepCopy())).Should(t.Succeed())
 


### PR DESCRIPTION
The nova-operator only depends on the public endpoint of Keystone so the original helper copied from nova-operator only simulates that one. However other operators like neutron-operator depends on the internal endpoint too. The keystone-operator by default creates both so the test helper also modified to simulate both.

```
$ oc get KeystoneAPI/keystone -o yaml | yq ".status.apiEndpoint"
{
  "internal": "http://keystone-internal.openstack.svc:5000",
  "public": "http://keystone-public-openstack.apps-crc.testing"
}
```