### PR TITLE
[pre-commit]skip branch check in CI

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -25,4 +25,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
+    - name: skip branch check
+      run: echo "SKIP=no-commit-to-branch" >> "$GITHUB_ENV"
     - uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: --all-files --show-diff-on-failure --verbose


### PR DESCRIPTION
We run all pre-commit on both push to branch and open pull request events. This means that we run it also against master after a PR is approved. In that case the no-commit-to-branch check, that enforces no direct commit to master branch fails, so we disable this check in CI. Locally it still make sense to keep it as it is good git hygiene to always work on a local topic branch.