### PR TITLE
Add NotRequested condition Reason

### DIFF
--- a/modules/common/condition/conditions.go
+++ b/modules/common/condition/conditions.go
@@ -74,6 +74,10 @@ const (
 	// RequestedReason (Severity=Info) documents a condition not in Status=True because the underlying object is not ready.
 	RequestedReason = "Requested"
 
+	// NotRequestedReason (Severity=Info) documents a condition not in
+	// Status=True because the underlying object has not yet been requested
+	NotRequestedReason = "NotRequested"
+
 	// CreationFailedReason (Severity=Error) documents a condition not in Status=True because the underlying object failed.
 	CreationFailedReason = "CreationFailed"
 


### PR DESCRIPTION
This reason will be used by the dataplane-operator to signal that the
deployment has not yet been requested.

Signed-off-by: James Slagle <jslagle@redhat.com>
