### PR TITLE
Add KeystoneAPI simulator

### DIFF
--- a/modules/test-operators/apis/common.go
+++ b/modules/test-operators/apis/common.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2023 Red Hat
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-logr/logr"
+)
+
+// Handler defines which URL patter is handled by which function
+type Handler struct {
+	// Pattern is the request URL to handle. If two patters are matching the
+	// same request then the handler for the longer pattern will be executed.
+	// Using the same pattern in two handlers will cause a panic.
+	Pattern string
+	// Func the the function that handles the request by writing a response
+	Func func(http.ResponseWriter, *http.Request)
+}
+
+// APIFixture is a base struct to implement OpenStack API simulators for the
+// EnvTest.
+type APIFixture struct {
+	log        logr.Logger
+	server     *FakeAPIServer
+	ownsServer bool
+	urlBase    string
+}
+
+func (f *APIFixture) logRequest(r *http.Request) {
+	f.log.Info("OpenStack API request", "method", r.Method, "URI", r.RequestURI)
+}
+
+// Cleanup stops the embedded http server if it was created by the fixture
+// during setup
+func (f *APIFixture) Cleanup() {
+	if f.ownsServer {
+		f.server.Cleanup()
+	}
+}
+
+// Endpoint is the URL the fixture's embedded http server listening on
+func (f *APIFixture) Endpoint() string {
+	return f.server.Endpoint() + f.urlBase
+}
+
+func (f *APIFixture) unexpectedRequest(w http.ResponseWriter, r *http.Request) {
+	f.log.Info("Unexpected OpenStackAPI request", "method", r.Method, "URI", r.RequestURI)
+	w.WriteHeader(500)
+	fmt.Fprintf(w, "Unexpected OpenStackAPI request %s %s", r.Method, r.RequestURI)
+}
+
+func (f *APIFixture) internalError(err error, msg string, w http.ResponseWriter, r *http.Request) {
+	f.log.Info("Internal error", "method", r.Method, "URI", r.RequestURI, "error", err, "message", msg)
+	w.WriteHeader(500)
+	fmt.Fprintf(w, "Internal error in %s %s: %s: %v", r.Method, r.RequestURI, msg, err)
+}

--- a/modules/test-operators/apis/keystone.go
+++ b/modules/test-operators/apis/keystone.go
@@ -1,0 +1,339 @@
+/*
+Copyright 2023 Red Hat
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/domains"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
+	"golang.org/x/exp/maps"
+)
+
+// KeystoneAPIFixture is simulator for the OpenStack Keystone API for EnvTest
+// You can simulate the happy path with the following code snippet:
+//
+//	f := NewKeystoneAPIFixtureWithServer(logger)
+//	f.Setup()
+//	DeferCleanup(f.Cleanup)
+//
+//	 name := th.CreateKeystoneAPIWithFixture(namespace, f)
+//	DeferCleanup(th.DeleteKeystoneAPI, name)
+//
+// But you can also inject failures by passing custom handlers to Setup:
+//
+//	f := NewKeystoneAPIFixtureWithServer(logger)
+//	f.Setup(
+//	    Handler{Patter: "/", Func: f.HandleVersion},
+//	    Handler{Patter: "/v3/auth/tokens", Func: f.HandleToken},
+//	    Handler{Patter: "/v3/users", Func: func(w http.ResponseWriter, r *http.Request) {
+//	        switch r.Method {
+//	        case "GET":
+//	            f.GetUsers(w, r)
+//	        case "POST":
+//	            w.WriteHeader(409)
+//	        }
+//	    }},
+//	)
+//	DeferCleanup(f.Cleanup)
+type KeystoneAPIFixture struct {
+	APIFixture
+	// Users is the map of user objects known by the fixture keyed by the user
+	// name
+	Users map[string]users.User
+	// Domains is the map of domain objects known by the fixture keyed by the
+	// domain name
+	Domains map[string]domains.Domain
+}
+
+// NewKeystoneAPIFixtureWithServer set up a keystone-api simulator with an
+// embedded http server
+func NewKeystoneAPIFixtureWithServer(log logr.Logger) *KeystoneAPIFixture {
+	server := &FakeAPIServer{}
+	server.Setup(log)
+	fixture := AddKeystoneAPIFixture(log, server)
+	fixture.ownsServer = true
+	return fixture
+}
+
+// AddKeystoneAPIFixture adds a keystone-api simulator to an already created
+// http server. This is useful if you need to have more than one openstack API
+// simulated but you don't want to start a separate http server for each.
+func AddKeystoneAPIFixture(log logr.Logger, server *FakeAPIServer) *KeystoneAPIFixture {
+	fixture := &KeystoneAPIFixture{
+		APIFixture: APIFixture{
+			server:     server,
+			log:        log,
+			urlBase:    "/identity",
+			ownsServer: false,
+		},
+		Users:   map[string]users.User{},
+		Domains: map[string]domains.Domain{},
+	}
+	return fixture
+}
+
+// Setup adds the API request handlers to the fixture. If no handlers is passed
+// then a basic set of well behaving handlers are added that will simulate the
+// happy path.
+// If you need to customize the behavior of the fixture, e.g. to inject faults,
+// then you can pass a list of handlers to register instead.
+func (f *KeystoneAPIFixture) Setup(handlers ...Handler) {
+	if len(handlers) == 0 {
+		f.registerNormalHandlers()
+	}
+	for _, handler := range handlers {
+		f.registerHandler(handler)
+	}
+}
+
+func (f *KeystoneAPIFixture) registerNormalHandlers() {
+	f.registerHandler(Handler{Pattern: "/", Func: f.HandleVersion})
+	f.registerHandler(Handler{Pattern: "/v3/auth/tokens", Func: f.HandleToken})
+	f.registerHandler(Handler{Pattern: "/v3/users", Func: f.HandleUsers})
+	f.registerHandler(Handler{Pattern: "/v3/domains", Func: f.HandleDomains})
+}
+
+func (f *KeystoneAPIFixture) registerHandler(handler Handler) {
+	f.server.mux.HandleFunc(f.urlBase+handler.Pattern, handler.Func)
+}
+
+// HandleVersion responds with a valid keystone version response
+func (f *KeystoneAPIFixture) HandleVersion(w http.ResponseWriter, r *http.Request) {
+	f.logRequest(r)
+	// The /identity URL matches to every request if no handle registered with a more
+	// specific URL pattern
+	if r.RequestURI != f.urlBase+"/" {
+		f.unexpectedRequest(w, r)
+		return
+	}
+
+	switch r.Method {
+	case "GET":
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprintf(w,
+			`
+			{
+				"versions":{
+				   "values":[
+					  {
+						 "id":"v3.14",
+						 "status":"stable",
+						 "links":[
+							{
+							   "rel":"self",
+							   "href":"%s/v3/"
+							}
+						 ],
+						 "media-types":[]
+					  }
+				   ]
+				}
+			 }
+			 `, f.Endpoint())
+	default:
+		f.unexpectedRequest(w, r)
+		return
+	}
+}
+
+// HandleToken responds with a valid keystone token
+func (f *KeystoneAPIFixture) HandleToken(w http.ResponseWriter, r *http.Request) {
+	f.logRequest(r)
+	switch r.Method {
+	case "POST":
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(202)
+		fmt.Fprintf(w,
+			`
+			{
+				"token":{
+				   "catalog":[
+					  {
+						 "endpoints":[
+							{
+							   "id":"e6ec29ecce164c3084ef308478080127",
+							   "interface":"public",
+							   "region_id":"RegionOne",
+							   "url":"%s",
+							   "region":"RegionOne"
+							}
+						 ],
+						 "id":"edad7277e52a47b3bfb2b7004f77110f",
+						 "type":"identity",
+						 "name":"keystone"
+					  }
+				   ]
+				}
+			 }
+			`, f.Endpoint())
+	default:
+		f.unexpectedRequest(w, r)
+		return
+	}
+}
+
+// HandleUsers handles the happy path of GET /v3/users and POST /v3/users API
+func (f *KeystoneAPIFixture) HandleUsers(w http.ResponseWriter, r *http.Request) {
+	f.logRequest(r)
+	switch r.Method {
+	case "GET":
+		f.GetUsers(w, r)
+	case "POST":
+		f.CreateUser(w, r)
+	default:
+		f.unexpectedRequest(w, r)
+		return
+	}
+}
+
+// GetUsers handles GET /v3/users based on the fixture internal state
+func (f *KeystoneAPIFixture) GetUsers(w http.ResponseWriter, r *http.Request) {
+	nameFilter := r.URL.Query().Get("name")
+	var us []users.User
+	if nameFilter == "" {
+		us = maps.Values(f.Users)
+	} else {
+		for name, user := range f.Users {
+			if name == nameFilter {
+				us = append(us, user)
+			}
+		}
+	}
+
+	var s struct {
+		Users []users.User `json:"users"`
+	}
+	s.Users = us
+
+	bytes, err := json.Marshal(&s)
+	if err != nil {
+		f.internalError(err, "Error during marshalling response", w, r)
+		return
+	}
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(200)
+	fmt.Fprint(w, string(bytes))
+}
+
+// CreateUser handles POST /v3/users and records the created user in memory
+func (f *KeystoneAPIFixture) CreateUser(w http.ResponseWriter, r *http.Request) {
+	bytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		f.internalError(err, "Error reading request body", w, r)
+		return
+	}
+	var s struct {
+		User users.User `json:"user"`
+	}
+	err = json.Unmarshal(bytes, &s)
+	if err != nil {
+		f.internalError(err, "Error during unmarshalling request", w, r)
+		return
+	}
+	if s.User.ID == "" {
+		s.User.ID = uuid.NewString()
+	}
+
+	f.Users[s.User.Name] = s.User
+
+	bytes, err = json.Marshal(&s)
+	if err != nil {
+		f.internalError(err, "Error during marshalling response", w, r)
+		return
+	}
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(201)
+	fmt.Fprint(w, string(bytes))
+}
+
+// HandleDomains handles the happy path of GET /v3/domains and POST /v3/domains API
+func (f *KeystoneAPIFixture) HandleDomains(w http.ResponseWriter, r *http.Request) {
+	f.logRequest(r)
+	switch r.Method {
+	case "GET":
+		f.GetDomains(w, r)
+	case "POST":
+		f.CreateDomain(w, r)
+	default:
+		f.unexpectedRequest(w, r)
+		return
+	}
+}
+
+// GetDomains handles GET /v3/domains based on the fixture internal state
+func (f *KeystoneAPIFixture) GetDomains(w http.ResponseWriter, r *http.Request) {
+	nameFilter := r.URL.Query().Get("name")
+	var ds []domains.Domain
+	if nameFilter == "" {
+		ds = maps.Values(f.Domains)
+	} else {
+		for name, domain := range f.Domains {
+			if name == nameFilter {
+				ds = append(ds, domain)
+			}
+		}
+	}
+
+	var s struct {
+		Domains []domains.Domain `json:"domains"`
+	}
+	s.Domains = ds
+
+	bytes, err := json.Marshal(&s)
+	if err != nil {
+		f.internalError(err, "Error during marshalling response", w, r)
+		return
+	}
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(200)
+	fmt.Fprint(w, string(bytes))
+}
+
+// CreateDomain handles POST /v3/domains and records the created domain in memory
+func (f *KeystoneAPIFixture) CreateDomain(w http.ResponseWriter, r *http.Request) {
+	bytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		f.internalError(err, "Error reading request body", w, r)
+		return
+	}
+	var s struct {
+		Domain domains.Domain `json:"domain"`
+	}
+	err = json.Unmarshal(bytes, &s)
+	if err != nil {
+		f.internalError(err, "Error during unmarshalling request", w, r)
+		return
+	}
+	if s.Domain.ID == "" {
+		s.Domain.ID = uuid.NewString()
+	}
+
+	f.Domains[s.Domain.Name] = s.Domain
+
+	bytes, err = json.Marshal(&s)
+	if err != nil {
+		f.internalError(err, "Error during marshalling response", w, r)
+		return
+	}
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(201)
+	fmt.Fprint(w, string(bytes))
+}

--- a/modules/test-operators/apis/server.go
+++ b/modules/test-operators/apis/server.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 Red Hat
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-logr/logr"
+)
+
+// FakeAPIServer represents an embedded http server to simulate http services
+type FakeAPIServer struct {
+	mux    *http.ServeMux
+	server *httptest.Server
+	log    logr.Logger
+}
+
+// Endpoint is the URL the embedded http server listening on
+func (s *FakeAPIServer) Endpoint() string {
+	return s.server.URL
+}
+
+// Setup creates and starts the embedded http server on localhost and on
+// a random port
+func (s *FakeAPIServer) Setup(log logr.Logger) {
+	s.log = log
+	s.mux = http.NewServeMux()
+	s.server = httptest.NewServer(s.mux)
+	// The / URL matches to every request if no handle registered with a more
+	// specific URL pattern
+	s.mux.HandleFunc("/", s.fallbackHandler)
+}
+
+func (s *FakeAPIServer) fallbackHandler(w http.ResponseWriter, r *http.Request) {
+	if r == nil {
+		s.log.Info("Unexpected OpenStackAPI nil request")
+		w.WriteHeader(500)
+		return
+	}
+
+	s.log.Info("Unexpected OpenStackAPI request", "method", r.Method, "URI", r.RequestURI)
+	w.WriteHeader(500)
+}
+
+// Cleanup stops the embedded http server
+func (s *FakeAPIServer) Cleanup() {
+	s.server.Close()
+}

--- a/modules/test-operators/go.mod
+++ b/modules/test-operators/go.mod
@@ -5,12 +5,14 @@ go 1.19
 require (
 	github.com/go-logr/logr v1.2.4
 	github.com/google/uuid v1.3.0
+	github.com/gophercloud/gophercloud v1.4.0
 	github.com/onsi/gomega v1.27.6
 	github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230609175832-5a9a30056080
 	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230612072624-8ebcfc19377a
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230606033311-3b01713e4d45
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.0.0-20230612101529-af40f24b2b62
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230602100742-579cb85d242d
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
 	sigs.k8s.io/controller-runtime v0.14.6
@@ -32,7 +34,6 @@ require (
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/gophercloud/gophercloud v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/modules/test-operators/go.sum
+++ b/modules/test-operators/go.sum
@@ -325,6 +325,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
The new KeystoneAPIFixture is able to simulate user and domain creation in OpenStack Keystone API by starting a local http server and responding to the API requests. Also the fixture allows registering test specific handlers to inject failure responses.

To utilize the fixture a new CreateKeystoneAPIWithFixture helper is added.

Example usage:
```golang
  f := NewKeystoneAPIFixtureWithServer(logger)
  f.Setup()
  DeferCleanup(f.Cleanup)

  name := th.CreateKeystoneAPIWithFixture(namespace, f)
  DeferCleanup(th.DeleteKeystoneAPI, name)
```