### PR TITLE
Add documentation for test helpers functions

### DIFF
--- a/modules/test-operators/go.mod
+++ b/modules/test-operators/go.mod
@@ -26,14 +26,12 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.1 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
-	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/gophercloud/gophercloud v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -44,7 +42,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/onsi/ginkgo/v2 v2.9.2 // indirect
 	github.com/openshift/api v3.9.0+incompatible // indirect
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20230522113906-6f4206cbf317 // indirect; indirect // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -59,7 +56,6 @@ require (
 	golang.org/x/term v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
-	golang.org/x/tools v0.7.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/modules/test-operators/go.sum
+++ b/modules/test-operators/go.sum
@@ -101,7 +101,6 @@ github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
-github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -164,7 +163,6 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
-github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
@@ -177,7 +175,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -224,8 +221,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
-github.com/onsi/ginkgo/v2 v2.9.2/go.mod h1:WHcJJG2dIlcCqVfBAwUCrJxSPFb6v4azBwgxeMeDuts=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
 github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
@@ -290,7 +287,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
@@ -511,7 +507,6 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
-golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/modules/test-operators/helpers/database.go
+++ b/modules/test-operators/helpers/database.go
@@ -19,7 +19,6 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -49,7 +48,15 @@ func (tc *TestHelper) CreateDBService(namespace string, mariadbCRName string, sp
 	return types.NamespacedName{Name: serviceName, Namespace: namespace}
 }
 
-// DeleteDBService -
+// DeleteDBService The function deletes the Service if exists and wait for it to disappear from the API.
+// If the Service does not exists then it is assumed to be successfully deleted.
+// Example:
+//
+//	th.DeleteDBService(types.NamespacedName{Name: "my-service", Namespace: "my-namespace"})
+//
+// or:
+//
+//	DeferCleanup(th.DeleteDBService, th.CreateDBService(cell0.MariaDBDatabaseName.Namespace, cell0.MariaDBDatabaseName.Name, serviceSpec))
 func (tc *TestHelper) DeleteDBService(name types.NamespacedName) {
 	t.Eventually(func(g t.Gomega) {
 		service := &corev1.Service{}
@@ -67,7 +74,11 @@ func (tc *TestHelper) DeleteDBService(name types.NamespacedName) {
 	}, tc.Timeout, tc.Interval).Should(t.Succeed())
 }
 
-// GetMariaDBDatabase -
+// GetMariaDBDatabase waits for and retrieves a MariaDBDatabase resource from the Kubernetes cluster
+//
+// Example:
+//
+//	mariadbDatabase := th.GetMariaDBDatabase(types.NamespacedName{Name: "my-mariadb-database", Namespace: "my-namespace"})
 func (tc *TestHelper) GetMariaDBDatabase(name types.NamespacedName) *mariadbv1.MariaDBDatabase {
 	instance := &mariadbv1.MariaDBDatabase{}
 	t.Eventually(func(g t.Gomega) {
@@ -76,14 +87,15 @@ func (tc *TestHelper) GetMariaDBDatabase(name types.NamespacedName) *mariadbv1.M
 	return instance
 }
 
-// ListMariaDBDatabase -
-func (tc *TestHelper) ListMariaDBDatabase(namespace string) *mariadbv1.MariaDBDatabaseList {
-	mariaDBDatabases := &mariadbv1.MariaDBDatabaseList{}
-	t.Expect(tc.K8sClient.List(tc.Ctx, mariaDBDatabases, client.InNamespace(namespace))).Should(t.Succeed())
-	return mariaDBDatabases
-}
-
-// SimulateMariaDBDatabaseCompleted -
+// SimulateMariaDBDatabaseCompleted simulates a completed state for a MariaDBDatabase resource in a Kubernetes cluster.
+//
+// Example:
+//
+//	th.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Name: "my-mariadb-database", Namespace: "my-namespace"})
+//
+// or
+//
+//	DeferCleanup(th.SimulateMariaDBDatabaseCompleted, types.NamespacedName{Name: "my-mariadb-database", Namespace: "my-namespace"})
 func (tc *TestHelper) SimulateMariaDBDatabaseCompleted(name types.NamespacedName) {
 	t.Eventually(func(g t.Gomega) {
 		db := tc.GetMariaDBDatabase(name)

--- a/modules/test-operators/helpers/keystone.go
+++ b/modules/test-operators/helpers/keystone.go
@@ -23,7 +23,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// CreateKeystoneAPI -
+// CreateKeystoneAPI creates a new KeystoneAPI instance with the specified namespace in the Kubernetes cluster.
+//
+// Example usage:
+//
+//	keystoneAPI := th.CreateKeystoneAPI(namespace)
+//	DeferCleanup(th.DeleteKeystoneAPI, keystoneAPI)
 func (tc *TestHelper) CreateKeystoneAPI(namespace string) types.NamespacedName {
 	keystone := &keystonev1.KeystoneAPI{
 		TypeMeta: metav1.TypeMeta{
@@ -54,7 +59,14 @@ func (tc *TestHelper) CreateKeystoneAPI(namespace string) types.NamespacedName {
 	return name
 }
 
-// DeleteKeystoneAPI -
+// DeleteKeystoneAPI deletes a KeystoneAPI resource from the Kubernetes cluster.
+//
+// # After the deletion, the function checks again if the KeystoneAPI is successfully deleted
+//
+// Example usage:
+//
+//	keystoneAPI := th.CreateKeystoneAPI(namespace)
+//	DeferCleanup(th.DeleteKeystoneAPI, keystoneAPI)
 func (tc *TestHelper) DeleteKeystoneAPI(name types.NamespacedName) {
 	t.Eventually(func(g t.Gomega) {
 		keystone := &keystonev1.KeystoneAPI{}
@@ -72,7 +84,14 @@ func (tc *TestHelper) DeleteKeystoneAPI(name types.NamespacedName) {
 	}, tc.Timeout, tc.Interval).Should(t.Succeed())
 }
 
-// GetKeystoneAPI -
+// GetKeystoneAPI retrieves a KeystoneAPI resource.
+//
+// The function returns a pointer to the retrieved KeystoneAPI resource.
+// example usage:
+//
+//	  keystoneAPIName := th.CreateKeystoneAPI(novaNames.NovaName.Namespace)
+//		 DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
+//		 keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
 func (tc *TestHelper) GetKeystoneAPI(name types.NamespacedName) *keystonev1.KeystoneAPI {
 	instance := &keystonev1.KeystoneAPI{}
 	t.Eventually(func(g t.Gomega) {
@@ -81,7 +100,11 @@ func (tc *TestHelper) GetKeystoneAPI(name types.NamespacedName) *keystonev1.Keys
 	return instance
 }
 
-// GetKeystoneService -
+// GetKeystoneService function retrieves and returns the KeystoneService resource
+//
+// Example usage:
+//
+//	keystoneServiceName := th.CreateKeystoneService(namespace)
 func (tc *TestHelper) GetKeystoneService(name types.NamespacedName) *keystonev1.KeystoneService {
 	instance := &keystonev1.KeystoneService{}
 	t.Eventually(func(g t.Gomega) {
@@ -90,7 +113,11 @@ func (tc *TestHelper) GetKeystoneService(name types.NamespacedName) *keystonev1.
 	return instance
 }
 
-// SimulateKeystoneServiceReady -
+// SimulateKeystoneServiceReady simulates the readiness of a KeystoneService
+// resource by seting the Ready condition of the KeystoneService to true
+//
+// Example usage:
+// keystoneServiceName := th.CreateKeystoneService(namespace)
 func (tc *TestHelper) SimulateKeystoneServiceReady(name types.NamespacedName) {
 	t.Eventually(func(g t.Gomega) {
 		service := tc.GetKeystoneService(name)
@@ -100,7 +127,11 @@ func (tc *TestHelper) SimulateKeystoneServiceReady(name types.NamespacedName) {
 	tc.Logger.Info("Simulated KeystoneService ready", "on", name)
 }
 
-// GetKeystoneEndpoint -
+// GetKeystoneEndpoint retrieves a KeystoneEndpoint resource from the Kubernetes cluster.
+//
+// Example usage:
+//
+//	keystoneEndpointName := th.CreateKeystoneEndpoint(namespace)
 func (tc *TestHelper) GetKeystoneEndpoint(name types.NamespacedName) *keystonev1.KeystoneEndpoint {
 	instance := &keystonev1.KeystoneEndpoint{}
 	t.Eventually(func(g t.Gomega) {
@@ -109,7 +140,13 @@ func (tc *TestHelper) GetKeystoneEndpoint(name types.NamespacedName) *keystonev1
 	return instance
 }
 
-// SimulateKeystoneEndpointReady -
+// SimulateKeystoneEndpointReady function retrieves the KeystoneEndpoint resource and
+// simulates a KeystoneEndpoint resource being marked as ready.
+//
+// Example usage:
+//
+//	keystoneEndpointName := th.CreateKeystoneEndpoint(namespace)
+//	th.SimulateKeystoneEndpointReady(keystoneEndpointName)
 func (tc *TestHelper) SimulateKeystoneEndpointReady(name types.NamespacedName) {
 	t.Eventually(func(g t.Gomega) {
 		endpoint := tc.GetKeystoneEndpoint(name)

--- a/modules/test-operators/helpers/transport.go
+++ b/modules/test-operators/helpers/transport.go
@@ -19,7 +19,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// GetTransportURL -
+// GetTransportURL retrieves a TransportURL resource with the specified name.
+//
+// Example usage:
+//
+//	th.GetTransportURL(types.NamespacedName{Name: "test-transporturl", Namespace: "test-namespace"})
 func (tc *TestHelper) GetTransportURL(name types.NamespacedName) *rabbitmqv1.TransportURL {
 	instance := &rabbitmqv1.TransportURL{}
 	t.Eventually(func(g t.Gomega) {
@@ -28,7 +32,12 @@ func (tc *TestHelper) GetTransportURL(name types.NamespacedName) *rabbitmqv1.Tra
 	return instance
 }
 
-// SimulateTransportURLReady -
+// SimulateTransportURLReady function retrieves the TransportURL and
+// simulates the readiness of a TransportURL resource.
+//
+// Example usage:
+//
+//	th.SimulateTransportURLReady(types.NamespacedName{Name: "test-transporturl", Namespace: "test-namespace"})
 func (tc *TestHelper) SimulateTransportURLReady(name types.NamespacedName) {
 	t.Eventually(func(g t.Gomega) {
 		transport := tc.GetTransportURL(name)

--- a/modules/test/go.mod
+++ b/modules/test/go.mod
@@ -5,7 +5,6 @@ go 1.19
 require (
 	github.com/go-logr/logr v1.2.4
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
-	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.6
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230425053514-21f91c966010
@@ -23,7 +22,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.1 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
-	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
@@ -49,7 +47,6 @@ require (
 	golang.org/x/term v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
-	golang.org/x/tools v0.7.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/modules/test/go.sum
+++ b/modules/test/go.sum
@@ -45,7 +45,6 @@ github.com/go-openapi/jsonreference v0.20.1/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
-github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -115,8 +114,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
-github.com/onsi/ginkgo/v2 v2.9.2/go.mod h1:WHcJJG2dIlcCqVfBAwUCrJxSPFb6v4azBwgxeMeDuts=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
 github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
@@ -146,7 +145,6 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -233,7 +231,6 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
-golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/modules/test/helpers/common.go
+++ b/modules/test/helpers/common.go
@@ -22,7 +22,6 @@ import (
 	"github.com/onsi/gomega"
 
 	"github.com/go-logr/logr"
-	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,10 +36,10 @@ type conditionsGetter interface {
 	GetConditions(name types.NamespacedName) condition.Conditions
 }
 
-// ConditionGetterFunc - recieves custom condition getters for operators specific needs
+// ConditionGetterFunc recieves custom condition getters for operators specific needs
 type ConditionGetterFunc func(name types.NamespacedName) condition.Conditions
 
-// GetConditions - implements conditions getter for operators specific needs
+// GetConditions implements conditions getter for operators specific needs
 func (f ConditionGetterFunc) GetConditions(name types.NamespacedName) condition.Conditions {
 	return f(name)
 }
@@ -85,18 +84,22 @@ func getTestTimeout(defaultTimeout time.Duration) time.Duration {
 	return time.Duration(timeout) * time.Second
 }
 
-// SkipInExistingCluster -
-func (tc *TestHelper) SkipInExistingCluster(message string) {
-	s := os.Getenv("USE_EXISTING_CLUSTER")
-	v, err := strconv.ParseBool(s)
-
-	if err == nil && v {
-		ginkgo.Skip("Skipped running against existing cluster. " + message)
-	}
-
-}
-
-// CreateUnstructured -
+// CreateUnstructured creates an unstructured Kubernetes object from a map of key-value pairs.
+//
+// Example usage:
+//
+//	  rawObj := map[string]interface{}{
+//	    "apiVersion": "nova.openstack.org/v1beta1",
+//			"kind":       "NovaAPI",
+//			"metadata": map[string]interface{}{
+//				"name":      name.Name,
+//				"namespace": name.Namespace,
+//			},
+//			"spec": spec,
+//	    },
+//	    ...
+//	  }
+//	  unstructuredObj := tc.CreateUnstructured(rawObj)
 func (tc *TestHelper) CreateUnstructured(rawObj map[string]interface{}) *unstructured.Unstructured {
 	tc.Logger.Info("Creating", "raw", rawObj)
 	unstructuredObj := &unstructured.Unstructured{Object: rawObj}
@@ -107,7 +110,7 @@ func (tc *TestHelper) CreateUnstructured(rawObj map[string]interface{}) *unstruc
 	return unstructuredObj
 }
 
-// GetName -
+// GetName function is used only in lib-common
 func (tc *TestHelper) GetName(obj client.Object) types.NamespacedName {
 	return types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
 }

--- a/modules/test/helpers/conditions.go
+++ b/modules/test/helpers/conditions.go
@@ -21,7 +21,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// ExpectCondition -
+// ExpectCondition - used to assert that a specific condition on a k8s resource
+// matches an expected status.
+//
+// Example usage:
+//
+//	th.ExpectCondition(
+//		novaNames.NovaName,
+//		ConditionGetterFunc(NovaConditionGetter),
+//		condition.ReadyCondition,
+//		corev1.ConditionFalse,
+//	)
 func (tc *TestHelper) ExpectCondition(
 	name types.NamespacedName,
 	getter conditionsGetter,
@@ -44,7 +54,19 @@ func (tc *TestHelper) ExpectCondition(
 	tc.Logger.Info("ExpectCondition succeeded", "type", conditionType, "expected status", expectedStatus, "on", name)
 }
 
-// ExpectConditionWithDetails -
+// ExpectConditionWithDetails used to assert that a specific condition on a k8s resource
+// matches an expected status, reason, and message.
+//
+// Example usage:
+//
+//	th.ExpectConditionWithDetails(
+//		novaNames.NovaName,
+//		ConditionGetterFunc(NovaConditionGetter),
+//		novav1.NovaAllCellsReadyCondition,
+//		corev1.ConditionFalse,
+//		condition.ErrorReason,
+//		"NovaCell creation failed for cell0(missing cell0 specification from Spec.CellTemplates)",
+//	 )
 func (tc *TestHelper) ExpectConditionWithDetails(
 	name types.NamespacedName,
 	getter conditionsGetter,

--- a/modules/test/helpers/configmap.go
+++ b/modules/test/helpers/configmap.go
@@ -18,13 +18,15 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetConfigMap -
+// GetConfigMap retrieves a ConfigMap resource from a k8s cluster.
+//
+// Example usage:
+// cm := th.GetConfigMap(types.NamespacedName{Namespace: "default", Name: "example-configmap"})
 func (tc *TestHelper) GetConfigMap(name types.NamespacedName) *corev1.ConfigMap {
 	cm := &corev1.ConfigMap{}
 	gomega.Eventually(func(g gomega.Gomega) {
@@ -34,7 +36,11 @@ func (tc *TestHelper) GetConfigMap(name types.NamespacedName) *corev1.ConfigMap 
 	return cm
 }
 
-// ListConfigMaps -
+// ListConfigMaps retrieves a list of ConfigMap resources from a specific namespace
+//
+// Example usage:
+//
+//	cms := th.ListConfigMaps(novaNames.MetadataName.Name)
 func (tc *TestHelper) ListConfigMaps(namespace string) *corev1.ConfigMapList {
 	cms := &corev1.ConfigMapList{}
 	gomega.Eventually(func(g gomega.Gomega) {
@@ -44,21 +50,15 @@ func (tc *TestHelper) ListConfigMaps(namespace string) *corev1.ConfigMapList {
 	return cms
 }
 
-// CreateEmptyConfigMap -
-func (tc *TestHelper) CreateEmptyConfigMap(name types.NamespacedName) *corev1.ConfigMap {
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.Name,
-			Namespace: name.Namespace,
-		},
-		Data: map[string]string{},
-	}
-	gomega.Expect(tc.K8sClient.Create(tc.Ctx, cm)).Should(gomega.Succeed())
-
-	return cm
-}
-
-// DeleteConfigMap -
+// DeleteConfigMap deletes a ConfigMap resource from a Kubernetes cluster.
+//
+// Example usage:
+//
+//	th.DeleteConfigMap(types.NamespacedName{Namespace: "default", Name: "example-configmap"})
+//
+// or
+//
+//	DeferCleanup(th.DeleteConfigMap, inventoryName)
 func (tc *TestHelper) DeleteConfigMap(name types.NamespacedName) {
 	gomega.Eventually(func(g gomega.Gomega) {
 		configMap := &corev1.ConfigMap{}
@@ -76,7 +76,12 @@ func (tc *TestHelper) DeleteConfigMap(name types.NamespacedName) {
 	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
 }
 
-// CreateConfigMap -
+// CreateConfigMap creates a new ConfigMap resource with the provided data.
+//
+// Example usage:
+//
+//	data := map[string]interface{}{"key": "value"}
+//	cm := th.CreateConfigMap(types.NamespacedName{Namespace: "default", Name: "example-configmap"}, data)
 func (tc *TestHelper) CreateConfigMap(name types.NamespacedName, data map[string]interface{}) client.Object {
 	raw := map[string]interface{}{
 		"apiVersion": "v1",
@@ -91,7 +96,7 @@ func (tc *TestHelper) CreateConfigMap(name types.NamespacedName, data map[string
 	return tc.CreateUnstructured(raw)
 }
 
-// AssertConfigMapExists -
+// AssertConfigMapExists used only in lib-common tests
 func (tc *TestHelper) AssertConfigMapExists(name types.NamespacedName) *corev1.ConfigMap {
 	instance := &corev1.ConfigMap{}
 	gomega.Eventually(func(g gomega.Gomega) {

--- a/modules/test/helpers/deployment.go
+++ b/modules/test/helpers/deployment.go
@@ -66,7 +66,15 @@ func (tc *TestHelper) SimulateDeploymentReplicaReady(name types.NamespacedName) 
 	tc.Logger.Info("Simulated Deployment success", "on", name)
 }
 
-// SimulateDeploymentReadyWithPods -
+// SimulateDeploymentReadyWithPods simulates a Deployment with ready replicas
+// by creating and updating the corresponding Pods.
+//
+// Example:
+//
+//	    th.SimulateDeploymentReadyWithPods(
+//					manilaTest.Instance,
+//					map[string][]string{manilaName.Namespace + "/internalapi": {"10.0.0.1"}},
+//				)
 func (tc *TestHelper) SimulateDeploymentReadyWithPods(name types.NamespacedName, networkIPs map[string][]string) {
 	ss := tc.GetDeployment(name)
 	for i := 0; i < int(*ss.Spec.Replicas); i++ {

--- a/modules/test/helpers/deployment.go
+++ b/modules/test/helpers/deployment.go
@@ -19,12 +19,27 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "k8s.io/api/apps/v1"
 )
 
-// GetDeployment -
+// GetDeployment - retrieves a Deployment resource from cluster.
+// The function uses the Gomega library's Eventually function to
+// repeatedly attempt to get the Deployment until it is successful or
+// the test's timeout is reached.
+//
+// The function returns a pointer to the retrieved Deployment.
+// If the function cannot find the Deployment within the timeout,
+// it will cause the test to fail.
+//
+// Example usage:
+//
+//	  deployment := th.GetDeployment(
+//					types.NamespacedName{
+//						Namespace: neutronAPIName.Namespace,
+//						Name:      "neutron",
+//					},
+//				)
 func (tc *TestHelper) GetDeployment(name types.NamespacedName) *appsv1.Deployment {
 	deployment := &appsv1.Deployment{}
 	gomega.Eventually(func(g gomega.Gomega) {
@@ -34,15 +49,11 @@ func (tc *TestHelper) GetDeployment(name types.NamespacedName) *appsv1.Deploymen
 	return deployment
 }
 
-// ListDeployments -
-func (tc *TestHelper) ListDeployments(namespace string) *appsv1.DeploymentList {
-	deployments := &appsv1.DeploymentList{}
-	gomega.Expect(tc.K8sClient.List(tc.Ctx, deployments, client.InNamespace(namespace))).Should(gomega.Succeed())
-
-	return deployments
-}
-
-// SimulateDeploymentReplicaReady -
+// SimulateDeploymentReplicaReady function retrieves the Deployment resource and
+// simulate that replicas are ready
+// Example usage:
+//
+//	th.SimulateDeploymentReplicaReady(ironicNames.INAName)
 func (tc *TestHelper) SimulateDeploymentReplicaReady(name types.NamespacedName) {
 	gomega.Eventually(func(g gomega.Gomega) {
 		deployment := tc.GetDeployment(name)

--- a/modules/test/helpers/instance.go
+++ b/modules/test/helpers/instance.go
@@ -21,7 +21,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// DeleteInstance -
+// DeleteInstance deletes a specified resource and waits until it's fully removed from the cluster.
+//
+// Example usage:
+//
+//	DeferCleanup(th.DeleteInstance, metadata_instance)
 func (tc *TestHelper) DeleteInstance(instance client.Object, opts ...client.DeleteOption) {
 	// We have to wait for the controller to fully delete the instance
 	tc.Logger.Info(

--- a/modules/test/helpers/job.go
+++ b/modules/test/helpers/job.go
@@ -21,7 +21,11 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 )
 
-// GetJob -
+// GetJob retrieves a specified Job resource from the cluster.
+//
+// Example usage:
+//
+//	job := th.GetJob(types.NamespacedName{Name: "cell-name", Namespace: "default"})
 func (tc *TestHelper) GetJob(name types.NamespacedName) *batchv1.Job {
 	job := &batchv1.Job{}
 	gomega.Eventually(func(g gomega.Gomega) {
@@ -31,7 +35,11 @@ func (tc *TestHelper) GetJob(name types.NamespacedName) *batchv1.Job {
 	return job
 }
 
-// ListJobs -
+// ListJobs retrieves a list of all job resources within a specified namespace.
+//
+// Example usage:
+//
+//	jobs := th.ListJobs("some-name").Items
 func (tc *TestHelper) ListJobs(namespace string) *batchv1.JobList {
 	jobs := &batchv1.JobList{}
 	gomega.Expect(tc.K8sClient.List(tc.Ctx, jobs, client.InNamespace(namespace))).Should(gomega.Succeed())
@@ -39,7 +47,12 @@ func (tc *TestHelper) ListJobs(namespace string) *batchv1.JobList {
 	return jobs
 }
 
-// SimulateJobFailure -
+// SimulateJobFailure function retrieves the Job and
+// simulates the failure of a Kubernetes Job resource.
+//
+// Example usage:
+//
+//	th.SimulateJobFailure(types.NamespacedName{Name: "test-job", Namespace: "default"})
 func (tc *TestHelper) SimulateJobFailure(name types.NamespacedName) {
 	gomega.Eventually(func(g gomega.Gomega) {
 		job := tc.GetJob(name)
@@ -53,7 +66,15 @@ func (tc *TestHelper) SimulateJobFailure(name types.NamespacedName) {
 	tc.Logger.Info("Simulated Job failure", "on", name)
 }
 
-// SimulateJobSuccess -
+// SimulateJobSuccess retrieves the Job and simulates the success of a Kubernetes Job resource.
+//
+// Note: In a real environment where the mariadb-operator is deployed, this
+// function may not be necessary as the Job could automatically run successfully
+// if the database user is manually registered in the DB service.
+//
+// Example usage:
+//
+//	th.SimulateJobSuccess(types.NamespacedName{Name: "test-job", Namespace: "default"})
 func (tc *TestHelper) SimulateJobSuccess(name types.NamespacedName) {
 	gomega.Eventually(func(g gomega.Gomega) {
 		job := tc.GetJob(name)

--- a/modules/test/helpers/namespace.go
+++ b/modules/test/helpers/namespace.go
@@ -20,7 +20,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// CreateNamespace -
+// CreateNamespace creates a Kubernetes Namespace resource.
+//
+// Example usage:
+//
+//	th.CreateNamespace("test-namespace")
+//
+// Note: the namespace should be unique and not be already present in the cluster, otherwise,
+// the function will fail.
 func (tc *TestHelper) CreateNamespace(name string) *corev1.Namespace {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -31,7 +38,17 @@ func (tc *TestHelper) CreateNamespace(name string) *corev1.Namespace {
 	return ns
 }
 
-// DeleteNamespace -
+// DeleteNamespace deletes a Kubernetes Namespace resource.
+//
+// Example usage:
+//
+//	th.DeleteNamespace("test-namespace")
+//
+// or
+//
+//	DeferCleanup(th.DeleteNamespace, namespace)
+//
+// Note: the namespace should exist in the cluster, otherwise, the function will fail.
 func (tc *TestHelper) DeleteNamespace(name string) {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/modules/test/helpers/networkattachmentdefinition.go
+++ b/modules/test/helpers/networkattachmentdefinition.go
@@ -23,7 +23,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// CreateNetworkAttachmentDefinition -
+// CreateNetworkAttachmentDefinition creates a new NetworkAttachmentDefinition resource.
+//
+// Example usage:
+//
+//	internalAPINADName := types.NamespacedName{Namespace: "testname", Name: "internalapi"}
+//	nad := th.CreateNetworkAttachmentDefinition(internalAPINADName)
 func (tc *TestHelper) CreateNetworkAttachmentDefinition(name types.NamespacedName) client.Object {
 	instance := &networkv1.NetworkAttachmentDefinition{
 		ObjectMeta: metav1.ObjectMeta{

--- a/modules/test/helpers/rbac.go
+++ b/modules/test/helpers/rbac.go
@@ -21,7 +21,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// GetServiceAccount -
+// GetServiceAccount fetches a ServiceAccount resource
+//
+// Example usage:
+//
+//	th.GetServiceAccount(types.NamespacedName{Name: "test-service-account", Namespace: "test-namespace"})
 func (tc *TestHelper) GetServiceAccount(name types.NamespacedName) *corev1.ServiceAccount {
 	instance := &corev1.ServiceAccount{}
 	gomega.Eventually(func(g gomega.Gomega) {
@@ -31,7 +35,11 @@ func (tc *TestHelper) GetServiceAccount(name types.NamespacedName) *corev1.Servi
 	return instance
 }
 
-// GetRole -
+// GetRole fetches a Role resource.
+//
+// Example usage:
+//
+//	th.GetRole(types.NamespacedName{Name: "test-role", Namespace: "test-namespace"})
 func (tc *TestHelper) GetRole(name types.NamespacedName) *rbacv1.Role {
 	instance := &rbacv1.Role{}
 	gomega.Eventually(func(g gomega.Gomega) {
@@ -41,7 +49,11 @@ func (tc *TestHelper) GetRole(name types.NamespacedName) *rbacv1.Role {
 	return instance
 }
 
-// GetRoleBinding -
+// GetRoleBinding - fetches a RoleBinding resource
+//
+// Example usage:
+//
+//	th.GetRoleBinding(types.NamespacedName{Name: "test-rolebinding", Namespace: "test-namespace"})
 func (tc *TestHelper) GetRoleBinding(name types.NamespacedName) *rbacv1.RoleBinding {
 	instance := &rbacv1.RoleBinding{}
 	gomega.Eventually(func(g gomega.Gomega) {

--- a/modules/test/helpers/route.go
+++ b/modules/test/helpers/route.go
@@ -21,7 +21,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// AssertRouteExists -
+// AssertRouteExists fetches a Route resource and asserts that the operation is successful.
+//
+// Example usage:
+//
+//	th.AssertRouteExists(types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "nova-public"})
 func (tc *TestHelper) AssertRouteExists(name types.NamespacedName) *routev1.Route {
 	instance := &routev1.Route{}
 	gomega.Eventually(func(g gomega.Gomega) {
@@ -31,7 +35,11 @@ func (tc *TestHelper) AssertRouteExists(name types.NamespacedName) *routev1.Rout
 	return instance
 }
 
-// AssertRouteNotExists -
+// AssertRouteNotExists fetch a Route resource and asserts that the resource does not exist.
+//
+// Example usage:
+//
+//	th.AssertRouteNotExists(types.NamespacedName{Name: "test-route", Namespace: "test-namespace"})
 func (tc *TestHelper) AssertRouteNotExists(name types.NamespacedName) *routev1.Route {
 	instance := &routev1.Route{}
 	gomega.Consistently(func(g gomega.Gomega) {

--- a/modules/test/helpers/secret.go
+++ b/modules/test/helpers/secret.go
@@ -20,11 +20,13 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetSecret -
+// GetSecret fetches a Secret resource
+//
+// Example usage:
+//
+//	secret := th.GetSecret(types.NamespacedName{Name: "test-secret", Namespace: "test-namespace"})
 func (tc *TestHelper) GetSecret(name types.NamespacedName) corev1.Secret {
 	secret := &corev1.Secret{}
 	gomega.Eventually(func(g gomega.Gomega) {
@@ -34,17 +36,11 @@ func (tc *TestHelper) GetSecret(name types.NamespacedName) corev1.Secret {
 	return *secret
 }
 
-// ListSecrets -
-func (tc *TestHelper) ListSecrets(namespace string) corev1.SecretList {
-	secrets := &corev1.SecretList{}
-	gomega.Eventually(func(g gomega.Gomega) {
-		g.Expect(tc.K8sClient.List(tc.Ctx, secrets, client.InNamespace(namespace))).Should(gomega.Succeed())
-	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
-
-	return *secrets
-}
-
-// CreateSecret -
+// CreateSecret creates a new Secret resource with provided data.
+//
+// Example usage:
+//
+//	secret := th.CreateSecret(types.NamespacedName{Name: "test-secret", Namespace: "test-namespace"}, map[string][]byte{"key": []byte("value")})
 func (tc *TestHelper) CreateSecret(name types.NamespacedName, data map[string][]byte) *corev1.Secret {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -60,12 +56,21 @@ func (tc *TestHelper) CreateSecret(name types.NamespacedName, data map[string][]
 	return secret
 }
 
-// CreateEmptySecret -
+// CreateEmptySecret creates a new empty Secret resource .
+//
+// Example usage:
+//
+//	secret := th.CreateSecret(types.NamespacedName{Name: "test-secret", Namespace: "test-namespace"})
 func (tc *TestHelper) CreateEmptySecret(name types.NamespacedName) *corev1.Secret {
 	return tc.CreateSecret(name, map[string][]byte{})
 }
 
-// DeleteSecret -
+// DeleteSecret deletes a Secret resource
+//
+// Example usage:
+//
+//	CreateNovaExternalComputeSSHSecret(sshSecretName)
+//	DeferCleanup(th.DeleteSecret, sshSecretName)
 func (tc *TestHelper) DeleteSecret(name types.NamespacedName) {
 	gomega.Eventually(func(g gomega.Gomega) {
 		secret := &corev1.Secret{}

--- a/modules/test/helpers/service.go
+++ b/modules/test/helpers/service.go
@@ -15,29 +15,17 @@ package helpers
 
 import (
 	"github.com/onsi/gomega"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// CreateService -
-func (tc *TestHelper) CreateService(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
-		"apiVersion": "v1",
-		"kind":       "Service",
-		"metadata": map[string]interface{}{
-			"name":      name.Name,
-			"namespace": name.Namespace,
-		},
-		"spec": spec,
-	}
-
-	return tc.CreateUnstructured(raw)
-}
-
-// GetService -
+// GetService retrieves a Service resource.
+//
+// Example usage:
+//
+//	th.GetService(types.NamespacedName{Name: "test-service", Namespace: "test-namespace"})
 func (tc *TestHelper) GetService(name types.NamespacedName) *corev1.Service {
 	instance := &corev1.Service{}
 	gomega.Eventually(func(g gomega.Gomega) {
@@ -47,7 +35,11 @@ func (tc *TestHelper) GetService(name types.NamespacedName) *corev1.Service {
 	return instance
 }
 
-// AssertServiceExists -
+// AssertServiceExists - asserts the existence of a Service resource in the Kubernetes cluster.
+//
+// Example usage:
+//
+//	th.AssertServiceExists(types.NamespacedName{Name: "neutron-public, Namespace: namespace})
 func (tc *TestHelper) AssertServiceExists(name types.NamespacedName) *corev1.Service {
 	instance := &corev1.Service{}
 	gomega.Eventually(func(g gomega.Gomega) {
@@ -56,7 +48,11 @@ func (tc *TestHelper) AssertServiceExists(name types.NamespacedName) *corev1.Ser
 	return instance
 }
 
-// DeleteService -
+// DeleteService - deletes a Service resource from the Kubernetes cluster.
+//
+// Example usage:
+//
+//	th.DeleteService(types.NamespacedName{Name: "test-service", Namespace: "test-namespace"})
 func (tc *TestHelper) DeleteService(name types.NamespacedName) {
 	instance := &corev1.Service{}
 

--- a/modules/test/helpers/statefulset.go
+++ b/modules/test/helpers/statefulset.go
@@ -20,7 +20,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetStatefulSet - retrieves a StatefulSet resource.
@@ -36,7 +35,7 @@ func (tc *TestHelper) GetStatefulSet(name types.NamespacedName) *appsv1.Stateful
 	return ss
 }
 
-// SimulateStatefulSetReplicaReady - retrieves the StatefulSet  and simulates
+// SimulateStatefulSetReplicaReady retrieves the StatefulSet  and simulates
 // a ready state for a StatefulSet's replica in a Kubernetes cluster.
 //
 // example usage:
@@ -53,7 +52,15 @@ func (tc *TestHelper) SimulateStatefulSetReplicaReady(name types.NamespacedName)
 	tc.Logger.Info("Simulated statefulset success", "on", name)
 }
 
-// SimulateStatefulSetReplicaReadyWithPods -
+// SimulateStatefulSetReplicaReadyWithPods simulates a StatefulSet with ready replicas
+// by creating and updating the corresponding Pods.
+//
+// example usage:
+//
+//		th.SimulateStatefulSetReplicaReadyWithPods(
+//	 	cell0.ConductorStatefulSetName,
+//	 	map[string][]string{cell0.CellName.Namespace + "/internalapi": {"10.0.0.1"}},
+//	 )
 func (tc *TestHelper) SimulateStatefulSetReplicaReadyWithPods(name types.NamespacedName, networkIPs map[string][]string) {
 	ss := tc.GetStatefulSet(name)
 	for i := 0; i < int(*ss.Spec.Replicas); i++ {

--- a/modules/test/helpers/statefulset.go
+++ b/modules/test/helpers/statefulset.go
@@ -23,7 +23,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetStatefulSet -
+// GetStatefulSet - retrieves a StatefulSet resource.
+//
+// example usage:
+//
+//	th.GetStatefulSet(types.NamespacedName{Name: "test-statefulset", Namespace: "test-namespace"})
 func (tc *TestHelper) GetStatefulSet(name types.NamespacedName) *appsv1.StatefulSet {
 	ss := &appsv1.StatefulSet{}
 	t.Eventually(func(g t.Gomega) {
@@ -32,15 +36,12 @@ func (tc *TestHelper) GetStatefulSet(name types.NamespacedName) *appsv1.Stateful
 	return ss
 }
 
-// ListStatefulSets -
-func (tc *TestHelper) ListStatefulSets(namespace string) *appsv1.StatefulSetList {
-	sss := &appsv1.StatefulSetList{}
-	t.Expect(tc.K8sClient.List(tc.Ctx, sss, client.InNamespace(namespace))).Should(t.Succeed())
-	return sss
-
-}
-
-// SimulateStatefulSetReplicaReady -
+// SimulateStatefulSetReplicaReady - retrieves the StatefulSet  and simulates
+// a ready state for a StatefulSet's replica in a Kubernetes cluster.
+//
+// example usage:
+//
+//	th.SimulateStatefulSetReplicaReady(types.NamespacedName{Name: "test-statefulset", Namespace: "test-namespace"})
 func (tc *TestHelper) SimulateStatefulSetReplicaReady(name types.NamespacedName) {
 	t.Eventually(func(g t.Gomega) {
 		ss := tc.GetStatefulSet(name)


### PR DESCRIPTION
With this changes documentation of all test helpers will be visible here: https://pkg.go.dev/github.com/openstack-k8s-operators/lib-common/modules/test@v0.0.0-20230510145530-3c8e9179fb6e/helpers