### PR TITLE
[test]Use Eventually for all k8s Update calls

### DIFF
--- a/modules/test/helpers/deployment.go
+++ b/modules/test/helpers/deployment.go
@@ -41,13 +41,13 @@ func (tc *TestHelper) ListDeployments(namespace string) *appsv1.DeploymentList {
 
 // SimulateDeploymentReplicaReady -
 func (tc *TestHelper) SimulateDeploymentReplicaReady(name types.NamespacedName) {
-	deployment := tc.GetDeployment(name)
-	// NOTE(gibi): We don't need to do this when run against a real
-	// env as there the deployment could reach the ready state automatically.
-	// But for that we would need another set of test setup, i.e. deploying
-	// the mariadb-operator.
+	gomega.Eventually(func(g gomega.Gomega) {
+		deployment := tc.GetDeployment(name)
 
-	deployment.Status.Replicas = 1
-	deployment.Status.ReadyReplicas = 1
-	gomega.Expect(tc.K8sClient.Status().Update(tc.Ctx, deployment)).To(gomega.Succeed())
+		deployment.Status.Replicas = 1
+		deployment.Status.ReadyReplicas = 1
+		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, deployment)).To(gomega.Succeed())
+	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
+
+	tc.Logger.Info("Simulated Deployment success", "on", name)
 }


### PR DESCRIPTION
We have couple of envtest helpers which call Update on existing k8s resources, for example to simulate a status condition. These updates can race with updates from the controller under test. In such case k8s will return 409. So this can cause random test instability. To avoid this this PR moves all Update calls into an Eventually block so the test will re-query the resource, reapply the change and redo the Update in a limited retry loop.

The only exception is CreateKeystoneAPI. That call creates an KeystoneAPI resource and updates its Status in a second Update call as the Status cannot be set during create as it needs a different client. In this case we don't expect anybody else to touch the KeystoneAPI resource.