### PR TITLE
Remove unused CronJobReadyRunningMessage

### DIFF
--- a/modules/common/condition/conditions.go
+++ b/modules/common/condition/conditions.go
@@ -239,9 +239,6 @@ const (
 	// CronJobReadyMessage
 	CronJobReadyMessage = "CronJob completed"
 
-	// CronJobReadyRunningMessage
-	CronJobReadyRunningMessage = "CronJob in progress"
-
 	// CronJobReadyErrorMessage
 	CronJobReadyErrorMessage = "CronJob error occurred %s"
 


### PR DESCRIPTION
This condition is not really used, because we only check whether the resource is created.