### PR TITLE
Service: Add interface to obtain IPFamilies

### DIFF
--- a/modules/common/service/service.go
+++ b/modules/common/service/service.go
@@ -52,6 +52,11 @@ func (s *Service) GetClusterIPs() []string {
 	return s.clusterIPs
 }
 
+// GetIPFamilies - returns the IP families of the created service
+func (s *Service) GetIPFamilies() []corev1.IPFamily {
+	return s.ipFamilies
+}
+
 // GetExternalIPs - returns a list of external IPs of the created service
 func (s *Service) GetExternalIPs() []string {
 	return s.externalIPs
@@ -158,6 +163,7 @@ func (s *Service) CreateOrPatch(
 
 	// update the service instance with the ip/host information
 	s.clusterIPs = service.Spec.ClusterIPs
+	s.ipFamilies = service.Spec.IPFamilies
 
 	if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
 		if len(service.Status.LoadBalancer.Ingress) > 0 {

--- a/modules/common/service/types.go
+++ b/modules/common/service/types.go
@@ -28,6 +28,7 @@ type Service struct {
 	timeout         time.Duration
 	clusterIPs      []string
 	externalIPs     []string
+	ipFamilies      []corev1.IPFamily
 	serviceHostname string
 }
 


### PR DESCRIPTION
Some config options require special format according to the IP version used by a service. For example memcache server list used by python-memcached requires inet6 prefix in case memcached listens at an IPv6 address.
    
This change introduces the interface to obtain spec.IPFamilies of Service resource so that we can determine which IP version is used by a service.
