### PR TITLE
Accept multiple labels for affinity

### DIFF
--- a/modules/common/affinity/affinity_test.go
+++ b/modules/common/affinity/affinity_test.go
@@ -52,7 +52,15 @@ func TestDistributePods(t *testing.T) {
 	t.Run("Default pod distribution", func(t *testing.T) {
 		g := NewWithT(t)
 
-		d := DistributePods("ThisSelector", []string{"selectorValue1", "selectorValue2"}, "ThisTopologyKey")
+		d := DistributePods(
+			map[string][]string{
+				"ThisSelector": {
+					"selectorValue1",
+					"selectorValue2",
+				},
+			},
+			"ThisTopologyKey",
+		)
 
 		g.Expect(d).To(BeEquivalentTo(affinityObj))
 	})


### PR DESCRIPTION
Some operators deploy multiple components and use the additional selector label (ComponentSelector) to distinguish components.