### PR TITLE
Get gophercloud system wide client

### DIFF
--- a/modules/openstack/openstack.go
+++ b/modules/openstack/openstack.go
@@ -40,6 +40,7 @@ type AuthOpts struct {
 	TenantName string
 	DomainName string
 	Region     string
+	Scope      *gophercloud.AuthScope
 }
 
 // NewOpenStack creates a new new instance of the openstack struct from a config struct
@@ -47,12 +48,16 @@ func NewOpenStack(
 	log logr.Logger,
 	cfg AuthOpts,
 ) (*OpenStack, error) {
+
 	opts := gophercloud.AuthOptions{
 		IdentityEndpoint: cfg.AuthURL,
 		Username:         cfg.Username,
 		Password:         cfg.Password,
 		TenantName:       cfg.TenantName,
 		DomainName:       cfg.DomainName,
+	}
+	if cfg.Scope != nil {
+		opts.Scope = cfg.Scope
 	}
 
 	provider, err := openstack.AuthenticatedClient(opts)


### PR DESCRIPTION
The `NewOpenStack` function is only used by `keystone` to get a an admin, system wide token that can be used by other operators through keystone service to register the associated resources. However, without `scope:system` `Glance` is not able to register the global limits defined in its main CR and it will fail configuring limits [1].
This patch ensures we have a system wide admin client that is able to act globally against the existing ctlplane.

[1] https://docs.openstack.org/glance/latest/admin/quotas.html#configuring-glance-for-per-tenant-quotas