### PR TITLE
[test]Fix PVC handling in SimulateDeployment

### DIFF
--- a/modules/test/helpers/deployment.go
+++ b/modules/test/helpers/deployment.go
@@ -92,7 +92,9 @@ func (tc *TestHelper) SimulateDeploymentReadyWithPods(name types.NamespacedName,
 		// with a missing volume. So to avoid that we remove every mount and
 		// volume from the pod we create here.
 		pod.Spec.Volumes = []corev1.Volume{}
-		pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{}
+		for i := range pod.Spec.Containers {
+			pod.Spec.Containers[i].VolumeMounts = []corev1.VolumeMount{}
+		}
 
 		var netStatus []networkv1.NetworkStatus
 		for network, IPs := range networkIPs {

--- a/modules/test/helpers/statefulset.go
+++ b/modules/test/helpers/statefulset.go
@@ -79,7 +79,9 @@ func (tc *TestHelper) SimulateStatefulSetReplicaReadyWithPods(name types.Namespa
 		// with a missing volume. So to avoid that we remove every mount and
 		// volume from the pod we create here.
 		pod.Spec.Volumes = []corev1.Volume{}
-		pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{}
+		for i := range pod.Spec.Containers {
+			pod.Spec.Containers[i].VolumeMounts = []corev1.VolumeMount{}
+		}
 
 		var netStatus []networkv1.NetworkStatus
 		for network, IPs := range networkIPs {


### PR DESCRIPTION
In #277 it was wrongly assumed that a StatefulSet of Deployment only has a single container spec and the volume mounts only removed from the first container. This leads to test failures in module using multiple containers per Pod.

Now this is fixed by dropping the mounts from each container.