### PR TITLE
Add support for configuring route annotations

### DIFF
--- a/modules/common/endpoint/endpoint.go
+++ b/modules/common/endpoint/endpoint.go
@@ -77,6 +77,7 @@ func ExposeEndpoints(
 	serviceName string,
 	endpointSelector map[string]string,
 	endpoints map[Endpoint]Data,
+	routeAnnotations map[string]string,
 	timeout time.Duration,
 ) (map[string]string, ctrl.Result, error) {
 	endpointMap := make(map[string]string)
@@ -181,6 +182,7 @@ func ExposeEndpoints(
 						Labels:         exportLabels,
 						ServiceName:    endpointName,
 						TargetPortName: endpointName,
+						Annotations:    routeAnnotations,
 					}),
 					exportLabels,
 					timeout,

--- a/modules/common/route/route.go
+++ b/modules/common/route/route.go
@@ -61,9 +61,10 @@ func GenericRoute(routeInfo *GenericRouteDetails) *routev1.Route {
 
 	result := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      routeInfo.Name,
-			Namespace: routeInfo.Namespace,
-			Labels:    routeInfo.Labels,
+			Name:        routeInfo.Name,
+			Namespace:   routeInfo.Namespace,
+			Labels:      routeInfo.Labels,
+			Annotations: routeInfo.Annotations,
 		},
 		Spec: routev1.RouteSpec{
 			To:   serviceRef,
@@ -83,8 +84,9 @@ func (r *Route) CreateOrPatch(
 ) (ctrl.Result, error) {
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.route.Name,
-			Namespace: r.route.Namespace,
+			Name:        r.route.Name,
+			Namespace:   r.route.Namespace,
+			Annotations: r.route.Annotations,
 		},
 	}
 

--- a/modules/common/route/types.go
+++ b/modules/common/route/types.go
@@ -37,4 +37,5 @@ type GenericRouteDetails struct {
 	ServiceName    string
 	TargetPortName string
 	FQDN           string
+	Annotations    map[string]string
 }


### PR DESCRIPTION
This patch adds the ability to configure route annotations for example `haproxy.router.openshift.io/timeout: 120s` for configureable timeout if the backend service is slow.