### PR TITLE
Add new Degraded condition status

### DIFF
--- a/modules/common/condition/conditions.go
+++ b/modules/common/condition/conditions.go
@@ -18,6 +18,16 @@ limitations under the License.
 
 package condition
 
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Common Condition Statuses used by API objects
+const (
+	// ConditionDegraded defines the status where a resource is ready but degraded (eg deployment have at least one pod but available pods are less than requested numbers)
+	ConditionDegraded corev1.ConditionStatus = "Degraded"
+)
+
 // Common Condition Types used by API objects.
 const (
 	// ReadyCondition defines the Ready condition type that summarizes the operational state of an API object.
@@ -109,6 +119,9 @@ const (
 	//
 	// ReadyInitMessage
 	ReadyInitMessage = "Setup started"
+
+	// ReadyDegraded
+	ReadyDegraded = "Setup degraded"
 
 	// ReadyMessage
 	ReadyMessage = "Setup complete"


### PR DESCRIPTION
This adds the new "Degraded" condition status to the existing "True", "False" and "Unkown". This status is similar to "True" and represents that the resources are ready to serve requests, but degraded. This is useful to expose status of deployments which might contain pods less than requested repolicas.