### PR TITLE
[envtest]Extend the PVC "handling" for Deployment

### DIFF
--- a/modules/common/test/helpers/deployment.go
+++ b/modules/common/test/helpers/deployment.go
@@ -95,6 +95,9 @@ func (tc *TestHelper) SimulateDeploymentReadyWithPods(name types.NamespacedName,
 		for i := range pod.Spec.Containers {
 			pod.Spec.Containers[i].VolumeMounts = []corev1.VolumeMount{}
 		}
+		for i := range pod.Spec.InitContainers {
+			pod.Spec.InitContainers[i].VolumeMounts = []corev1.VolumeMount{}
+		}
 
 		var netStatus []networkv1.NetworkStatus
 		for network, IPs := range networkIPs {

--- a/modules/common/test/helpers/statefulset.go
+++ b/modules/common/test/helpers/statefulset.go
@@ -82,6 +82,9 @@ func (tc *TestHelper) SimulateStatefulSetReplicaReadyWithPods(name types.Namespa
 		for i := range pod.Spec.Containers {
 			pod.Spec.Containers[i].VolumeMounts = []corev1.VolumeMount{}
 		}
+		for i := range pod.Spec.InitContainers {
+			pod.Spec.InitContainers[i].VolumeMounts = []corev1.VolumeMount{}
+		}
 
 		var netStatus []networkv1.NetworkStatus
 		for network, IPs := range networkIPs {


### PR DESCRIPTION
The a41eea4f21fec66a74e7d90ee7102bcb2f6f0ac0 started dropping the volume attachments from the Pod containers during simulating statefulset and deployments readyness by creating Pods. However it missed the fact that the Pod Spec might have initContainers. This is fixed now.