### PR TITLE
Give specific domain id for user/project

### DIFF
--- a/modules/openstack/project.go
+++ b/modules/openstack/project.go
@@ -27,6 +27,7 @@ import (
 type Project struct {
 	Name        string
 	Description string
+	DomainID    string
 }
 
 // CreateProject - creates project with projectName and projectDescription if it does not exist
@@ -35,7 +36,7 @@ func (o *OpenStack) CreateProject(
 	p Project,
 ) (string, error) {
 	var projectID string
-	allPages, err := projects.List(o.osclient, projects.ListOpts{Name: p.Name}).AllPages()
+	allPages, err := projects.List(o.osclient, projects.ListOpts{Name: p.Name, DomainID: p.DomainID}).AllPages()
 	if err != nil {
 		return projectID, err
 	}
@@ -49,8 +50,9 @@ func (o *OpenStack) CreateProject(
 		createOpts := projects.CreateOpts{
 			Name:        p.Name,
 			Description: p.Description,
+			DomainID:    p.DomainID,
 		}
-		log.Info(fmt.Sprintf("Creating project %s", p.Name))
+		log.Info(fmt.Sprintf("Creating project %s in %s", p.Name, p.DomainID))
 		project, err := projects.Create(o.osclient, createOpts).Extract()
 		if err != nil {
 			return projectID, err

--- a/modules/openstack/user.go
+++ b/modules/openstack/user.go
@@ -95,6 +95,8 @@ func (o *OpenStack) GetUser(
 
 	if len(allUsers) == 0 {
 		return nil, fmt.Errorf(fmt.Sprintf("%s %s", userName, UserNotFound))
+	} else if len(allUsers) > 1 {
+		return nil, fmt.Errorf(fmt.Sprintf("multiple users named \"%s\" found", userName))
 	}
 
 	return &allUsers[0], nil

--- a/modules/openstack/user.go
+++ b/modules/openstack/user.go
@@ -58,11 +58,14 @@ func (o *OpenStack) CreateUser(
 		userID = user.ID
 	} else {
 		createOpts := users.CreateOpts{
-			Name:             u.Name,
-			DefaultProjectID: u.ProjectID,
-			Password:         u.Password,
-			DomainID:         u.DomainID,
+			Name:     u.Name,
+			Password: u.Password,
+			DomainID: u.DomainID,
 		}
+		if u.ProjectID != "" {
+			createOpts.DefaultProjectID = u.ProjectID
+		}
+
 		user, err := users.Create(o.GetOSClient(), createOpts).Extract()
 		if err != nil {
 			return userID, err


### PR DESCRIPTION
Keystone supports "domain" and users, groups and projects belong to a specific domain, and it's possible that multiple entries with the same name exist in different domains.

This introduces the interface to specify the domain where the user or the project should exist, to avoid unexpected behavior caused by such "duplicate" entities.