### PR TITLE
Skip redundant update when removing a finalizer

### DIFF
--- a/modules/database/funcs.go
+++ b/modules/database/funcs.go
@@ -313,9 +313,11 @@ func (d *Database) DeleteFinalizer(
 	ctx context.Context,
 	h *helper.Helper,
 ) error {
-	controllerutil.RemoveFinalizer(d.database, h.GetFinalizer())
-	if err := h.GetClient().Update(ctx, d.database); err != nil && !k8s_errors.IsNotFound(err) {
-		return err
+	if controllerutil.RemoveFinalizer(d.database, h.GetFinalizer()) {
+		err := h.GetClient().Update(ctx, d.database)
+		if err != nil && !k8s_errors.IsNotFound(err) {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
We don't have to update a CR when the CR does not contain the finalizer being removed. This also removes some unused/redundant function from the Reconciler struct.