### PR TITLE
Unpin deps after dev-preview

### DIFF
--- a/modules/certmanager/go.mod
+++ b/modules/certmanager/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.1.0
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20230824094610-976b18ca2875
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.0.0-20230612101529-af40f24b2b62
 	go.uber.org/zap v1.25.0
 	k8s.io/api v0.26.7


### PR DESCRIPTION
On the main branch we want to continue tracking the main branch of our operator dependencies.