### PR TITLE
Merge Annotations and Labels in CreateOrPatch

### DIFF
--- a/modules/certmanager/certificate.go
+++ b/modules/certmanager/certificate.go
@@ -91,7 +91,7 @@ func (c *Certificate) CreateOrPatch(
 
 	op, err := controllerutil.CreateOrPatch(ctx, h.GetClient(), cert, func() error {
 		cert.Labels = util.MergeStringMaps(cert.Labels, c.certificate.Labels)
-		cert.Annotations = c.certificate.Annotations
+		cert.Annotations = util.MergeStringMaps(cert.Annotations, c.certificate.Annotations)
 		cert.Spec = c.certificate.Spec
 
 		err := controllerutil.SetControllerReference(h.GetBeforeObject(), cert, h.GetScheme())

--- a/modules/certmanager/issuer.go
+++ b/modules/certmanager/issuer.go
@@ -104,7 +104,7 @@ func (i *Issuer) CreateOrPatch(
 
 	op, err := controllerutil.CreateOrPatch(ctx, h.GetClient(), issuer, func() error {
 		issuer.Labels = util.MergeStringMaps(issuer.Labels, i.issuer.Labels)
-		issuer.Annotations = i.issuer.Annotations
+		issuer.Annotations = util.MergeStringMaps(issuer.Annotations, i.issuer.Annotations)
 		issuer.Spec = i.issuer.Spec
 
 		err := controllerutil.SetControllerReference(h.GetBeforeObject(), issuer, h.GetScheme())

--- a/modules/common/configmap/configmap.go
+++ b/modules/common/configmap/configmap.go
@@ -74,7 +74,7 @@ func createOrPatchConfigMap(
 	// create or update the CM
 	op, err := controllerutil.CreateOrPatch(ctx, h.GetClient(), configMap, func() error {
 
-		configMap.Labels = cm.Labels
+		configMap.Labels = util.MergeStringMaps(configMap.Labels, cm.Labels)
 		// add data from templates
 		renderedTemplateData, err := util.GetTemplateData(cm)
 		if err != nil {

--- a/modules/common/route/route.go
+++ b/modules/common/route/route.go
@@ -133,8 +133,8 @@ func (r *Route) CreateOrPatch(
 	}
 
 	op, err := controllerutil.CreateOrPatch(ctx, h.GetClient(), route, func() error {
-		route.Labels = r.route.Labels
-		route.Annotations = r.route.Annotations
+		route.Labels = util.MergeStringMaps(route.Labels, r.route.Labels)
+		route.Annotations = util.MergeStringMaps(route.Annotations, r.route.Annotations)
 		route.Spec = r.route.Spec
 		if len(route.Spec.Host) == 0 && len(route.Status.Ingress) > 0 {
 			route.Spec.Host = route.Status.Ingress[0].Host

--- a/modules/common/secret/secret.go
+++ b/modules/common/secret/secret.go
@@ -153,7 +153,7 @@ func createOrUpdateSecret(
 
 	// create or update the CM
 	op, err := controllerutil.CreateOrPatch(ctx, h.GetClient(), secret, func() error {
-		secret.Labels = st.Labels
+		secret.Labels = util.MergeStringMaps(secret.Labels, st.Labels)
 		// add data from templates
 		renderedTemplateData, err := util.GetTemplateData(st)
 		if err != nil {

--- a/modules/common/service/service.go
+++ b/modules/common/service/service.go
@@ -273,8 +273,8 @@ func (s *Service) CreateOrPatch(
 	}
 
 	op, err := controllerutil.CreateOrPatch(ctx, h.GetClient(), service, func() error {
-		service.Labels = s.service.Labels
-		service.Annotations = s.service.Annotations
+		service.Labels = util.MergeStringMaps(service.Labels, s.service.Labels)
+		service.Annotations = util.MergeStringMaps(service.Annotations, s.service.Annotations)
 		service.Spec = s.service.Spec
 
 		err := controllerutil.SetControllerReference(h.GetBeforeObject(), service, h.GetScheme())


### PR DESCRIPTION
Identified in OCP4.13 where metallb adds an annotation to the service when handling it, it resulted in reconcile loop since the current service CreateOrPatch did not expect that annotations will be altered outside the owner.

This changes the different functions to merge Labels and Annotations in CreateOr Patch instead of assigning.