### PR TITLE
Addin specialized utility function for genereting mock ssh secrets

### DIFF
--- a/modules/common/test/helpers/secret.go
+++ b/modules/common/test/helpers/secret.go
@@ -65,6 +65,15 @@ func (tc *TestHelper) CreateEmptySecret(name types.NamespacedName) *corev1.Secre
 	return tc.CreateSecret(name, map[string][]byte{})
 }
 
+// CreateSSHSecret creates new secret containing mock "ssh-privatekey"
+//
+// Example usage:
+//
+// sshSecret := th.CreateSSHSecret(types.NamespacedName{Name: "test-ssh-secret", Namespace: "test-namespace"})
+func (tc *TestHelper) CreateSSHSecret(name types.NamespacedName) *corev1.Secret {
+	return tc.CreateSecret(name, map[string][]byte{"ssh-privatekey": []byte("foo")})
+}
+
 // DeleteSecret deletes a Secret resource
 //
 // Example usage:


### PR DESCRIPTION
These secrets are used in a considerable number of tests. Implementing separate function for generating them in each repo is suboptimal.

At this point this would see use in the dataplane-operator repo, but I expect that in the future a similar fixture would be useful for tests of other operators that have to use ssh connections. 