### PR TITLE
Support template parameters in configmap/secret customData

### DIFF
--- a/modules/common/configmap/configmap.go
+++ b/modules/common/configmap/configmap.go
@@ -85,7 +85,13 @@ func createOrPatchConfigMap(
 		// Note: this can overwrite data rendered from GetTemplateData() if key is same
 		if len(cm.CustomData) > 0 {
 			for k, v := range cm.CustomData {
-				configMap.Data[k] = v
+				vExpanded, err := util.ExecuteTemplateData(v, cm.ConfigOptions)
+				if err == nil {
+					configMap.Data[k] = vExpanded
+				} else {
+					h.GetLogger().Info(fmt.Sprintf("Skipped customData expansion due to: %s", err))
+					configMap.Data[k] = v
+				}
 			}
 		}
 

--- a/modules/common/secret/secret.go
+++ b/modules/common/secret/secret.go
@@ -165,7 +165,13 @@ func createOrUpdateSecret(
 		// Note: this can overwrite data rendered from GetTemplateData() if key is same
 		if len(st.CustomData) > 0 {
 			for k, v := range st.CustomData {
-				dataString[k] = v
+				vExpanded, err := util.ExecuteTemplateData(v, st.ConfigOptions)
+				if err == nil {
+					dataString[k] = vExpanded
+				} else {
+					h.GetLogger().Info(fmt.Sprintf("Skipped customData expansion due to: %s", err))
+					dataString[k] = v
+				}
 			}
 		}
 


### PR DESCRIPTION
Template parameter expansion has only been supported in template files themselves, and not in any other sources supplied in the customData. This patch extends support for expanding parameters in all customData strings.

The intent is to support template parameters in customServiceConfig data. A common use case is when a service's config parameter needs to be set to a value that can be templated, e.g. the service's own password.

Consider the glance service when it's configured to use cinder for a backend. The final configuration needs to specify the 'cinder_store_password', which currently requires two things.

1. The cloud admin will need to create a secret containing the setting, and reference it in the customServiceConfigSecrets.
2. The cloud admin will need to track down the actual value (i.e. glance's password) in order to put it in the secret.

An alternative approach would allow the cloud admin to use a template parameter, whereby glance's CR could reference the password like this:

    glance:
      template:
        customServiceConfig: |
          [cinder_backend]
          cinder_store_password = {{ .ServicePassword }}

The only restriction is the service's controller must support the parameter, meaning it must include it in its templateParameters. If a CR references a parameter that isn't supported, the controller will log an error stating, 'map has no entry for key "BadParam"'.