### PR TITLE
[TLS] Don't set commonName and only use subjectAltNames

### DIFF
--- a/modules/certmanager/certificate.go
+++ b/modules/certmanager/certificate.go
@@ -57,9 +57,7 @@ func NewCertificate(
 // minimal spec should be:
 // Spec:
 //
-//	commonName: keystone-public-openstack.apps-crc.testing
 //	dnsNames:
-//	- keystone-public-openstack
 //	- keystone-public-openstack.apps-crc.testing
 //	issuerRef:
 //	   kind: Issuer
@@ -166,8 +164,7 @@ func EnsureCert(
 		namespace,
 		labels,
 		certmgrv1.CertificateSpec{
-			CommonName: hostnames[0],
-			DNSNames:   hostnames,
+			DNSNames: hostnames,
 			Duration: &metav1.Duration{
 				Duration: *duration,
 			},

--- a/modules/certmanager/issuer.go
+++ b/modules/certmanager/issuer.go
@@ -127,7 +127,7 @@ func (i *Issuer) CreateOrPatch(
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		h.GetLogger().Info(fmt.Sprintf("Route %s - %s", issuer.Name, op))
+		h.GetLogger().Info(fmt.Sprintf("Issuer %s - %s", issuer.Name, op))
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
commonName has a max length of 64 chars, which easy can be reached in route DNS names scheme.

From [1]
~~~
RFC 2818, published in May 2000, deprecates the use of the Common Name (CN) field in HTTPS
certificates for subject name verification. Instead, it recommends using the
 “Subject Alternative Name” extension (SAN) of the “dns name” type.
~~~

Lets not set the commonName an just use the subjectAltNames for our certs.

[1] https://cloud.redhat.com/blog/details-on-https-common-name-deprecation-in-openshift-4.10