### PR TITLE
[certmanager] Add EnsureCertForServicesWithSelector() and EnsureCertForServiceWithSelector()

### DIFF
--- a/modules/certmanager/go.mod
+++ b/modules/certmanager/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/onsi/gomega v1.30.0
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20231215134849-9acca0025036
 	go.uber.org/zap v1.26.0
+	golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611
 	k8s.io/api v0.26.11
 	k8s.io/apimachinery v0.26.11
 	k8s.io/client-go v0.26.11

--- a/modules/certmanager/go.sum
+++ b/modules/certmanager/go.sum
@@ -328,6 +328,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611 h1:qCEDpW1G+vcj3Y7Fy52pEM1AWm3abj8WimGYejI3SC4=
+golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/modules/common/test/helpers/service.go
+++ b/modules/common/test/helpers/service.go
@@ -18,6 +18,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -33,6 +34,27 @@ func (tc *TestHelper) GetService(name types.NamespacedName) *corev1.Service {
 	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
 
 	return instance
+}
+
+// CreateService creates a new k8s service resource with provided data.
+//
+// Example usage:
+//
+//	secret := th.CreateService(types.NamespacedName{Name: "test-secret", Namespace: "test-namespace"}, map[string]string{}, corev1.ServiceSpec{...})
+func (tc *TestHelper) CreateService(name types.NamespacedName, labels map[string]string, svcSpec corev1.ServiceSpec) *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+			Labels:    labels,
+		},
+		Spec: svcSpec,
+	}
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(tc.K8sClient.Create(tc.Ctx, svc)).Should(gomega.Succeed())
+	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
+
+	return svc
 }
 
 // AssertServiceExists - asserts the existence of a Service resource in the Kubernetes cluster.


### PR DESCRIPTION
Adds function EnsureCertForServicesWithSelector() to create certs for a k8s services identified by a label selector and EnsureCertForServicesWithSelector() where the expectation is that the selector maps to a single service.