### PR TITLE
[service/route] allow updating labels and services

### DIFF
--- a/modules/common/route/route.go
+++ b/modules/common/route/route.go
@@ -133,8 +133,8 @@ func (r *Route) CreateOrPatch(
 	}
 
 	op, err := controllerutil.CreateOrPatch(ctx, h.GetClient(), route, func() error {
-		route.Labels = util.MergeStringMaps(route.Labels, r.route.Labels)
-		route.Annotations = util.MergeStringMaps(route.Annotations, r.route.Annotations)
+		route.Labels = util.MergeStringMaps(r.route.Labels, route.Labels)
+		route.Annotations = util.MergeStringMaps(r.route.Annotations, route.Annotations)
 		route.Spec = r.route.Spec
 		if len(route.Spec.Host) == 0 && len(route.Status.Ingress) > 0 {
 			route.Spec.Host = route.Status.Ingress[0].Host

--- a/modules/common/service/service.go
+++ b/modules/common/service/service.go
@@ -306,8 +306,8 @@ func (s *Service) CreateOrPatch(
 	}
 
 	op, err := controllerutil.CreateOrPatch(ctx, h.GetClient(), service, func() error {
-		service.Labels = util.MergeStringMaps(service.Labels, s.service.Labels)
-		service.Annotations = util.MergeStringMaps(service.Annotations, s.service.Annotations)
+		service.Labels = util.MergeStringMaps(s.service.Labels, service.Labels)
+		service.Annotations = util.MergeStringMaps(s.service.Annotations, service.Annotations)
 		service.Spec = s.service.Spec
 
 		err := controllerutil.SetControllerReference(h.GetBeforeObject(), service, h.GetScheme())


### PR DESCRIPTION
with 18d0ea2c06a85f0d9a329c8f7ffbff41afeb0f1c we introduced merging annotations and labels. It was required as other components can add annotations to a created service:

~~~
Author: Martin Schuppert <mschuppert@redhat.com>
Date:   Wed Sep 27 09:06:26 2023 +0200

    Merge Annotations and Labels in CreateOrPatch

    Identified in OCP4.13 where metallb adds an annotation to the
    service when handling it, it resulted in reconcile loop since
    the current service CreateOrPatch did not expect that annotations
    will be altered outside the owner.

    This changes the different functions to merge Labels and Annotations
    in CreateOr Patch instead of assigning.
~~~

With the current order of how the labels on routes and services get created does not allow to change a value of an existing key as how the merge func works.

This changes the order that existing labels and annotations of services and routes get merged so that those from an existing object gets merged into the one either provided via overrides or calculated by the operators. This still allows other components to add entries, and the operators/users to updated existing ones.