### PR TITLE
[renovate]Do not bump common module within lib-common

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,10 @@
       "matchPackageNames": ["github.com/cert-manager/cert-manager"],
       "allowedVersions": "< 1.12.0",
       "enabled": true
+    },
+    {
+      "matchPackageNames": ["github.com/openstack-k8s-operators/lib-common/modules/common"],
+      "enabled": false
     }
   ],
   "postUpgradeTasks": {


### PR DESCRIPTION
Both openstack and certmanager module depends on the common module within the same repo and both go.mod files has a replace line to use the in repo version of that dependency. Therefore it is not necessary to bump the pseudoversion of the common module in those go.mod files. So this PR disables those renovate bumps to avoid unnecessary CI churn.