### PR TITLE
service: expose PublishNotReadyAddresses for GenericService

### DIFF
--- a/modules/common/service/service.go
+++ b/modules/common/service/service.go
@@ -253,10 +253,11 @@ func GenericService(svcInfo *GenericServiceDetails) *corev1.Service {
 			Labels:    svcInfo.Labels,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector:  svcInfo.Selector,
-			Ports:     ports,
-			ClusterIP: svcInfo.ClusterIP,
-			Type:      corev1.ServiceTypeClusterIP,
+			Selector:                 svcInfo.Selector,
+			Ports:                    ports,
+			ClusterIP:                svcInfo.ClusterIP,
+			Type:                     corev1.ServiceTypeClusterIP,
+			PublishNotReadyAddresses: svcInfo.PublishNotReadyAddresses,
 		},
 	}
 }

--- a/modules/common/service/service_test.go
+++ b/modules/common/service/service_test.go
@@ -137,8 +137,9 @@ func TestGenericService(t *testing.T) {
 							NodePort:    0,
 						},
 					},
-					Selector: map[string]string{},
-					Type:     corev1.ServiceTypeClusterIP,
+					Selector:                 map[string]string{},
+					Type:                     corev1.ServiceTypeClusterIP,
+					PublishNotReadyAddresses: false,
 				},
 			},
 		},
@@ -183,7 +184,57 @@ func TestGenericService(t *testing.T) {
 					Selector: map[string]string{
 						"foo": "bar",
 					},
-					Type: corev1.ServiceTypeClusterIP,
+					Type:                     corev1.ServiceTypeClusterIP,
+					PublishNotReadyAddresses: false,
+				},
+			},
+		},
+		{
+			name: "Headless service with not ready addresses",
+			service: GenericServiceDetails{
+				Name:      "foo",
+				Namespace: "namespace",
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+				Selector: map[string]string{
+					"foo": "bar",
+				},
+				Ports: []corev1.ServicePort{
+					{
+						Name:     "port",
+						Port:     int32(80),
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+				ClusterIP:                "None",
+				PublishNotReadyAddresses: true,
+			},
+			want: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "namespace",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:        "port",
+							Protocol:    corev1.ProtocolTCP,
+							AppProtocol: nil,
+							Port:        int32(80),
+							TargetPort:  intstr.FromInt(0),
+							NodePort:    0,
+						},
+					},
+					Selector: map[string]string{
+						"foo": "bar",
+					},
+					Type:                     corev1.ServiceTypeClusterIP,
+					ClusterIP:                "None",
+					PublishNotReadyAddresses: true,
 				},
 			},
 		},

--- a/modules/common/service/types.go
+++ b/modules/common/service/types.go
@@ -81,9 +81,10 @@ type GenericServiceDetails struct {
 	Labels    map[string]string
 	Selector  map[string]string
 	// deprecated, use Ports
-	Port      GenericServicePort
-	Ports     []corev1.ServicePort
-	ClusterIP string
+	Port                     GenericServicePort
+	Ports                    []corev1.ServicePort
+	ClusterIP                string
+	PublishNotReadyAddresses bool
 }
 
 // GenericServicePort -


### PR DESCRIPTION
There are times where one wants to create a service that enables endpoints for pods which are not ready as per their healthchecks. For example, for bootstrapping a clustered service such as Galera or during the failover of an A/P service such as Redis.

The type corev1.Service addresses this use case by providing option PublishNotReadyAddresses. Expose this option in libcommon type GenericServiceDetails to build the proper Service object when using GenericService().