### PR TITLE
Drop DebugCommand const

### DIFF
--- a/modules/common/const.go
+++ b/modules/common/const.go
@@ -28,8 +28,6 @@ const (
 	CustomServiceConfigFileName = "custom.conf"
 	// CustomPolicyFileName - file name used to add the policy rule customizations
 	CustomPolicyFileName = "custom.yaml"
-	// DebugCommand - Default debug command for pods
-	DebugCommand = "/usr/local/bin/kolla_set_configs && /bin/sleep infinity"
 	// InputHashName -Name of the hash of hashes of all resources used to indentify an input change
 	InputHashName = "input"
 )


### PR DESCRIPTION
The service and job Debug feature is removed from the operators in favor of using oc debug directly.

Implements: [OSPRH-4290](https://issues.redhat.com/browse/OSPRH-4290)