### PR TITLE
FIPS: Add common/ocp module

### DIFF
--- a/modules/common/go.mod
+++ b/modules/common/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.28.7
 	k8s.io/apimachinery v0.28.7
 	k8s.io/client-go v0.28.7
@@ -64,7 +65,6 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.28.7 // indirect
 	k8s.io/component-base v0.28.7 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect

--- a/modules/common/ocp/ocp.go
+++ b/modules/common/ocp/ocp.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2024 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocp
+
+import (
+	"context"
+
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// IsFipsCluster - Check if OCP has fips enabled which is a day 1 operation
+func IsFipsCluster(ctx context.Context, h *helper.Helper) (bool, error) {
+	configMap := &corev1.ConfigMap{}
+	err := h.GetClient().Get(ctx, types.NamespacedName{Name: "cluster-config-v1", Namespace: "kube-system"}, configMap)
+	if err != nil {
+		return false, err
+	}
+
+	var installConfig map[string]interface{}
+	installConfigYAML := configMap.Data["install-config"]
+	err = yaml.Unmarshal([]byte(installConfigYAML), &installConfig)
+	if err != nil {
+		return false, err
+	}
+
+	fipsEnabled, ok := installConfig["fips"].(bool)
+	if !ok {
+		return false, nil
+	}
+	return fipsEnabled, nil
+}


### PR DESCRIPTION
For FIPS support we need to be able to tell when an OCP cluster has been deployed in FIPS mode (it's a day one operation).

This patch adds the `IsFipsCluster` function that checks if FIPS is enabled or not.

The way to do that is checking the install-config YAML that is stored in the cluster-config-v1 Config Map.

If we find the fips key, and it has the true value, then it's deployed in FIPS mode, otherwise it isn't.

Related patch: https://github.com/openstack-k8s-operators/openstack-operator/pull/657

Jira: #OSPRH-4666