### PR TITLE
Fix missing string formatting and return msg as an error

### DIFF
--- a/modules/common/job/job.go
+++ b/modules/common/job/job.go
@@ -291,8 +291,7 @@ func GetJobWithName(
 	job := &batchv1.Job{}
 	err := h.GetClient().Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, job)
 	if err != nil {
-		h.GetLogger().Info("GetJobWithName %s err: %w", name, err)
-		return job, err
+		return job, fmt.Errorf("GetJobWithName %s err: %w", name, err)
 	}
 
 	return job, nil


### PR DESCRIPTION
String formatting is missing if job is not found. Instead of logging an error, return the error with the message. Jobs need to be restarted to be executed again, but might be deleted already because of their TTL. In this case this is not an error and should be handled properly by the calling code.