### PR TITLE
[CronJob]Support updating config

### DIFF
--- a/modules/common/cronjob/cronjob.go
+++ b/modules/common/cronjob/cronjob.go
@@ -46,7 +46,11 @@ func (cj *CronJob) CreateOrPatch(
 	ctx context.Context,
 	h *helper.Helper,
 ) (ctrl.Result, error) {
+	cronjob := &batchv1.CronJob{}
+	cronjob.ObjectMeta = cj.cronjob.ObjectMeta
+
 	op, err := controllerutil.CreateOrPatch(ctx, h.GetClient(), cj.cronjob, func() error {
+		cronjob.Spec = cj.cronjob.Spec
 		err := controllerutil.SetControllerReference(h.GetBeforeObject(), cj.cronjob, h.GetScheme())
 		if err != nil {
 			return err


### PR DESCRIPTION
Until now the update on the CronJob Spec fields was ignored. So
for example Schedule could not be upgraded.

This is fixed know.
