### PR TITLE
Add annotation for specifying ingress target port.

### DIFF
--- a/modules/common/service/types.go
+++ b/modules/common/service/types.go
@@ -42,6 +42,8 @@ const (
 	EndpointPublic Endpoint = "public"
 	// AnnotationIngressCreateKey -
 	AnnotationIngressCreateKey = "core.openstack.org/ingress_create"
+	// AnnotationIngressTargetPortNameKey -
+	AnnotationIngressTargetPortNameKey = "core.openstack.org/ingress_target_port_name"
 	// AnnotationEndpointKey -
 	AnnotationEndpointKey = "endpoint"
 	// AnnotationHostnameKey -


### PR DESCRIPTION
In telemetry-operator, we use the cluster-observability-operator to manage prometheus. COO creates a prometheus service with a target port name "web", which is different from the name of the service. COO doesn't create routes. This annotation lets us specify the intended target port name and use the openstack-operator to create a route for us after adding this annotation to the COO created service.