### PR TITLE
conditions: add RestoreLastTransitionTimes function

### DIFF
--- a/modules/common/condition/funcs.go
+++ b/modules/common/condition/funcs.go
@@ -380,6 +380,17 @@ func (conditions *Conditions) Mirror(t Type) *Condition {
 	return mirrorCondition
 }
 
+// RestoreLastTransitionTimes - Updates each condition's LastTransitionTime when its state
+// matches the one in a list of "saved" conditions.
+func RestoreLastTransitionTimes(conditions *Conditions, savedConditions Conditions) {
+	for idx, cond := range *conditions {
+		savedCond := savedConditions.Get(cond.Type)
+		if savedCond != nil && HasSameState(&cond, savedCond) {
+			(*conditions)[idx].LastTransitionTime = savedCond.LastTransitionTime
+		}
+	}
+}
+
 // getConditionGroups groups a list of conditions according to status, severity values.
 // The groups are sorted by Status and Severity.
 func (conditions *Conditions) getConditionGroups() []conditionGroup {


### PR DESCRIPTION
The RestoreLastTransitionTimes function facilitates preserving a condition's LastTransitionTime if a controller reinitializes its conditions at the start of every reconcilation. Controllers can use the following sequence in their reconciliation code:

- Save a copy of the current conditions
- Reinitialize conditions to Unknown
- Reconcile, which updates the conditions to their new state
- Call RestoreLastTransitionTimes

For conditions whose state doesn't change, the LastTransitionTime is set back to the time recorded in the saved copy. This prevents the LastTransitionTime from changing unless the condition itself actually changes state.