### PR TITLE
Add .ObservedGeneration to statefulset and deployments test module

### DIFF
--- a/modules/common/test/helpers/deployment.go
+++ b/modules/common/test/helpers/deployment.go
@@ -61,6 +61,7 @@ func (tc *TestHelper) SimulateDeploymentReplicaReady(name types.NamespacedName) 
 
 		deployment.Status.Replicas = 1
 		deployment.Status.ReadyReplicas = 1
+		deployment.Status.ObservedGeneration = deployment.Generation
 		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, deployment)).To(gomega.Succeed())
 	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
 
@@ -120,6 +121,7 @@ func (tc *TestHelper) SimulateDeploymentReadyWithPods(name types.NamespacedName,
 		depl := tc.GetDeployment(name)
 		depl.Status.Replicas = 1
 		depl.Status.ReadyReplicas = 1
+		depl.Status.ObservedGeneration = depl.Generation
 		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, depl)).To(gomega.Succeed())
 
 	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())

--- a/modules/common/test/helpers/statefulset.go
+++ b/modules/common/test/helpers/statefulset.go
@@ -49,6 +49,7 @@ func (tc *TestHelper) SimulateStatefulSetReplicaReady(name types.NamespacedName)
 		ss := tc.GetStatefulSet(name)
 		ss.Status.Replicas = 1
 		ss.Status.ReadyReplicas = 1
+		ss.Status.ObservedGeneration = ss.Generation
 		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, ss)).To(gomega.Succeed())
 
 	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
@@ -109,6 +110,7 @@ func (tc *TestHelper) SimulateStatefulSetReplicaReadyWithPods(name types.Namespa
 		ss := tc.GetStatefulSet(name)
 		ss.Status.Replicas = 1
 		ss.Status.ReadyReplicas = 1
+		ss.Status.ObservedGeneration = ss.Generation
 		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, ss)).To(gomega.Succeed())
 
 	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())


### PR DESCRIPTION
In order to be able to rollout the full `.ObservedGeneration` pattern we need `envTests` to pass if this is added as a condition to mark a `Deployment` or `StatefulSet` `Ready`. 
This change introduces this parameter for the test module so we can take it into account in the envTests when the `DeploymentReadyCondition` is computed.