### PR TITLE
Add AdditionalSubjectNames and the related function to tls module

### DIFF
--- a/modules/common/tls/tls.go
+++ b/modules/common/tls/tls.go
@@ -67,6 +67,13 @@ const (
 
 	// TLSHashName - Name of the hash of hashes of all cert resources used to identify a change
 	TLSHashName = "certs"
+
+	// AdditionalSubjectNamesKey - Comma separated list of additionalSubjectNames
+	// that should be passed to the CertificateRequest
+	AdditionalSubjectNamesKey = "additionalSubjectNames"
+
+	// DefaultClusterInternalDomain - cluster internal dns domain
+	DefaultClusterInternalDomain = "cluster.local"
 )
 
 // SimpleService defines the observed state of TLS for a single service

--- a/modules/common/util/map.go
+++ b/modules/common/util/map.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package util
 
-import "sort"
+import (
+	"sort"
+	"strings"
+)
 
 // InitMap - Inititialise a map to an empty map if it is nil.
 func InitMap(m *map[string]string) {
@@ -98,4 +101,21 @@ func MergeMaps[K comparable, V any](baseMap map[K]V, extraMaps ...map[K]V) map[K
 	}
 
 	return mergedMap
+}
+
+// GetStringListFromMap - It returns a list of strings based on a comma
+// separated list assigned to the map key. This is usually invoked to normalize
+// annotation fields where a list of items is expressed with a comma separated
+// list of strings.
+// Example:
+// input: in["additionalSubjectNamesKey"] = "foo.bar,bar.svc,*.foo.bar"
+// output: [foo.bar bar.svc *.foo.bar]
+func GetStringListFromMap(in map[string]string, key string) []string {
+	strList := []string{}
+	if h, ok := in[key]; ok {
+		if h != "" {
+			strList = strings.Split(h, ",")
+		}
+	}
+	return strList
 }

--- a/modules/common/util/map_test.go
+++ b/modules/common/util/map_test.go
@@ -133,3 +133,25 @@ func TestMergeMaps(t *testing.T) {
 		g.Expect(mergedIntMap).To(HaveKeyWithValue("c", 3))
 	})
 }
+
+func TestGetStringsFromMap(t *testing.T) {
+	t.Run("Get List of strings from map", func(t *testing.T) {
+		g := NewWithT(t)
+
+		key := "additionalSubjectNamesKey"
+
+		m1 := map[string]string{
+			key: "*.foo.svc,*.bar.svc,example.svc.clusterlocal",
+		}
+
+		m2 := map[string]string{
+			"otherkey": "*.foo.svc,*.bar.svc,example.svc.clusterlocal",
+		}
+
+		lstr := GetStringListFromMap(m1, key)
+		g.Expect(lstr).To(HaveLen(3))
+
+		lstr = GetStringListFromMap(m2, key)
+		g.Expect(lstr).To(BeEmpty())
+	})
+}


### PR DESCRIPTION
`AdditionalSubjectNames` represents the key to access a comma separated list of `additionalSubjectNames` that should be passed to the `CertificateRequest`.