### PR TITLE
Align finalizer with Custom Resource Definition doc

### DIFF
--- a/modules/common/helper/helper.go
+++ b/modules/common/helper/helper.go
@@ -19,6 +19,7 @@ package helper
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -72,7 +73,7 @@ func NewHelper(obj client.Object, crClient client.Client, kclient kubernetes.Int
 		before:       unstructuredObj,
 		beforeObject: obj.DeepCopyObject().(client.Object),
 		logger:       log,
-		finalizer:    gvk.Kind,
+		finalizer:    strings.ToLower("openstack.org/" + gvk.Kind),
 	}, nil
 }
 


### PR DESCRIPTION
Per Custom Resource Definition docs [1], custom finalizer names are expected to be in format "consist of a domain name, a forward slash and the name of the finalizer" (e.g. foo.bar/name).

This aligns the finalizer provided by the helper to follow this definition and uses openstack.org/<gkv.kind> (all lower case) as the finalizer.

[1] https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers:~:text=Identifiers%20of%20custom%20finalizers%20consist%20of%20a%20domain%20name%2C%20a%20forward%20slash%20and%20the%20name%20of%20the%20finalizer