### PR TITLE
Add webhook package, to be used for common webhook checks

### DIFF
--- a/modules/common/webhook/storage.go
+++ b/modules/common/webhook/storage.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2024 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// ValidateStorageRequest - validates a storage request meets a provided min size. Depending on the
+// err (bool) the check result is either a warning or an invalid error.
+//
+// example usage:
+//
+//   - return a warning
+//
+//     ValidateStorageRequest(<path>, "500M", "5G", false)
+//
+//   - return an error
+//
+//     ValidateStorageRequest(<path>, "500M", "5G", true)
+func ValidateStorageRequest(basePath *field.Path, req string, min string, err bool) (admission.Warnings, field.ErrorList) {
+	storageRequestProd := resource.MustParse(min)
+	storageRequest := resource.MustParse(req)
+	allErrs := field.ErrorList{}
+	allWarn := []string{}
+
+	if storageRequest.Cmp(storageRequestProd) < 0 {
+		res := fmt.Sprintf("%s: %s is not appropriate for production! For production use at least %s!",
+			basePath.Child("storageRequest").String(), req, min)
+		// Return error if err == true was provided, else a warning
+		if err {
+			allErrs = append(allErrs, field.Invalid(basePath, req, res))
+		} else {
+			allWarn = append(allWarn, res)
+		}
+	}
+	return allWarn, allErrs
+}

--- a/modules/common/webhook/storage_test.go
+++ b/modules/common/webhook/storage_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2024 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestValidateStorageRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      string
+		min      string
+		err      bool
+		wantErr  bool
+		wantWarn bool
+	}{
+		{
+			name:     "req is higher then min",
+			req:      "500M",
+			min:      "400M",
+			err:      true,
+			wantErr:  false,
+			wantWarn: false,
+		},
+		{
+			name:     "req is lower then min, want error",
+			req:      "500M",
+			min:      "1G",
+			err:      true,
+			wantErr:  true,
+			wantWarn: false,
+		},
+		{
+			name:     "req is lower then min, want warn",
+			req:      "500M",
+			min:      "1G",
+			err:      false,
+			wantErr:  false,
+			wantWarn: true,
+		},
+		{
+			name:     "req is equal min",
+			req:      "500M",
+			min:      "500M",
+			err:      true,
+			wantErr:  false,
+			wantWarn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			p := field.NewPath("foo")
+
+			warns, errs := ValidateStorageRequest(p, tt.req, tt.min, tt.err)
+			if tt.wantWarn {
+				g.Expect(warns).To(HaveLen(1))
+			} else {
+				g.Expect(warns).To(BeEmpty())
+			}
+			if tt.wantErr {
+				g.Expect(errs).To(HaveLen(1))
+			} else {
+				g.Expect(errs).To(BeEmpty())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds webhook package, intended to be a collection of webhook funcs, which can be used by the service operators.

This initial one will add a `ValidateStorageRequest()` func which validates a storage request meets a provided min size. Depending on the err (bool) parameter, the check result is either a warning or an invalid error.