### PR TITLE
DNM Revert "[svc] return error if no LoadBalancer IP"

### DIFF
--- a/modules/common/service/service.go
+++ b/modules/common/service/service.go
@@ -338,8 +338,6 @@ func (s *Service) CreateOrPatch(
 			for _, ingr := range service.Status.LoadBalancer.Ingress {
 				s.externalIPs = append(s.externalIPs, ingr.IP)
 			}
-		} else {
-			return ctrl.Result{}, fmt.Errorf("%s LoadBalancer IP still pending", s.service.Name)
 		}
 	}
 

--- a/modules/common/test/functional/service_test.go
+++ b/modules/common/test/functional/service_test.go
@@ -221,17 +221,9 @@ var _ = Describe("service package", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		_, err = s.CreateOrPatch(ctx, h)
-		// when LoadBalancer service gets created and LB has not assigned an LB IP we exect an error
-		Expect(err).Should(HaveOccurred())
-		Expect(err.Error()).Should(ContainSubstring("test-svc LoadBalancer IP still pending"))
-
-		// simulate LoadBalancer assigned IP and updated the k8s service to have a LB IP
-		th.SimulateLoadBalancerServiceIP(types.NamespacedName{Namespace: namespace, Name: "test-svc"})
-
-		// LoadBalancer IP still pending error should _NOT_ occure
-		_, err = s.CreateOrPatch(ctx, h)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(s.GetExternalIPs()).To(Equal([]string{"1.1.1.1"}))
+		svc := th.AssertServiceExists(types.NamespacedName{Namespace: namespace, Name: "test-svc"})
+		Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
 
 		// NONE endpoint with port
 		endpointURL, err := s.GetAPIEndpoint(nil, ptr.To(service.ProtocolNone), "")


### PR DESCRIPTION
This reverts commit 38b791ecf590b82914fe720250823b54c9c45b46.
This pull-request is only to add it as depends-on to the commit https://review.rdoproject.org/r/c/testproject/+/53195
I suspect this patch is making the gate fail earlier, once confirmed I'll properly find a way to fix gate.