### PR TITLE
[18.0.0-proposed] Add function to check for OCP IPv6 cluster network

### DIFF
--- a/modules/common/ocp/ocp.go
+++ b/modules/common/ocp/ocp.go
@@ -18,7 +18,6 @@ package ocp
 
 import (
 	"context"
-	"strings"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 
@@ -26,6 +25,7 @@ import (
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	k8s_utils "k8s.io/utils/net"
 )
 
 // IsFipsCluster - Check if OCP has fips enabled which is a day 1 operation
@@ -59,7 +59,7 @@ func HasIPv6ClusterNetwork(ctx context.Context, h *helper.Helper) (bool, error) 
 	}
 
 	for _, clusterNetwork := range networkConfig.Status.ClusterNetwork {
-		if strings.Count(clusterNetwork.CIDR, ":") >= 2 {
+		if k8s_utils.IsIPv6CIDRString(clusterNetwork.CIDR) {
 			return true, nil
 		}
 	}

--- a/modules/common/test/helpers/ocp.go
+++ b/modules/common/test/helpers/ocp.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2024 Red Hat
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ocp_config "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateClusterNetworkConfig creates a fake cluster network config CR
+func (tc *TestHelper) CreateClusterNetworkConfig() client.Object {
+	instance := &ocp_config.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster",
+			Namespace: "",
+		},
+		Status: ocp_config.NetworkStatus{
+			ClusterNetwork: []ocp_config.ClusterNetworkEntry{
+				{
+					CIDR:       "172.16.0.0/25",
+					HostPrefix: 24,
+				},
+			},
+		},
+	}
+	gomega.Expect(tc.K8sClient.Create(tc.Ctx, instance)).Should(gomega.Succeed())
+
+	return instance
+}

--- a/modules/test/openshift_crds/config/v1/network_crd.yaml
+++ b/modules/test/openshift_crds/config/v1/network_crd.yaml
@@ -1,0 +1,163 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: networks.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Network
+    listKind: NetworkList
+    plural: networks
+    singular: network
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Network holds cluster-wide information about Network. The canonical name is `cluster`. It is used to configure the desired network configuration, such as: IP address pools for services/pod IPs, network plugin, etc. Please view network.spec for an explanation on what applies when configuring this resource. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration. As a general rule, this SHOULD NOT be read directly. Instead, you should consume the NetworkStatus, as it indicates the currently deployed configuration. Currently, most spec fields are immutable after installation. Please view the individual ones for further details on each.
+              type: object
+              properties:
+                clusterNetwork:
+                  description: IP address pool to use for pod IPs. This field is immutable after installation.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
+                    type: object
+                    properties:
+                      cidr:
+                        description: The complete block for pod IPs.
+                        type: string
+                      hostPrefix:
+                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
+                        type: integer
+                        format: int32
+                        minimum: 0
+                externalIP:
+                  description: externalIP defines configuration for controllers that affect Service.ExternalIP. If nil, then ExternalIP is not allowed to be set.
+                  type: object
+                  properties:
+                    autoAssignCIDRs:
+                      description: autoAssignCIDRs is a list of CIDRs from which to automatically assign Service.ExternalIP. These are assigned when the service is of type LoadBalancer. In general, this is only useful for bare-metal clusters. In Openshift 3.x, this was misleadingly called "IngressIPs". Automatically assigned External IPs are not affected by any ExternalIPPolicy rules. Currently, only one entry may be provided.
+                      type: array
+                      items:
+                        type: string
+                    policy:
+                      description: policy is a set of restrictions applied to the ExternalIP field. If nil or empty, then ExternalIP is not allowed to be set.
+                      type: object
+                      properties:
+                        allowedCIDRs:
+                          description: allowedCIDRs is the list of allowed CIDRs.
+                          type: array
+                          items:
+                            type: string
+                        rejectedCIDRs:
+                          description: rejectedCIDRs is the list of disallowed CIDRs. These take precedence over allowedCIDRs.
+                          type: array
+                          items:
+                            type: string
+                networkType:
+                  description: 'NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN This field is immutable after installation.'
+                  type: string
+                serviceNetwork:
+                  description: IP address pool for services. Currently, we only support a single entry here. This field is immutable after installation.
+                  type: array
+                  items:
+                    type: string
+                serviceNodePortRange:
+                  description: The port range allowed for Services of type NodePort. If not specified, the default of 30000-32767 will be used. Such Services without a NodePort specified will have one automatically allocated from this range. This parameter can be updated after the cluster is installed.
+                  type: string
+                  pattern: ^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                clusterNetwork:
+                  description: IP address pool to use for pod IPs.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
+                    type: object
+                    properties:
+                      cidr:
+                        description: The complete block for pod IPs.
+                        type: string
+                      hostPrefix:
+                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
+                        type: integer
+                        format: int32
+                        minimum: 0
+                clusterNetworkMTU:
+                  description: ClusterNetworkMTU is the MTU for inter-pod networking.
+                  type: integer
+                migration:
+                  description: Migration contains the cluster network migration configuration.
+                  type: object
+                  properties:
+                    mtu:
+                      description: MTU contains the MTU migration configuration.
+                      type: object
+                      properties:
+                        machine:
+                          description: Machine contains MTU migration configuration for the machine's uplink.
+                          type: object
+                          properties:
+                            from:
+                              description: From is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: To is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                        network:
+                          description: Network contains MTU migration configuration for the default network.
+                          type: object
+                          properties:
+                            from:
+                              description: From is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: To is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                    networkType:
+                      description: 'NetworkType is the target plugin that is to be deployed. Currently supported values are: OpenShiftSDN, OVNKubernetes'
+                      type: string
+                      enum:
+                        - OpenShiftSDN
+                        - OVNKubernetes
+                networkType:
+                  description: NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).
+                  type: string
+                serviceNetwork:
+                  description: IP address pool for services. Currently, we only support a single entry here.
+                  type: array
+                  items:
+                    type: string
+      served: true
+      storage: true


### PR DESCRIPTION
The RabbitMQ config differs for IPv6 so add a function to determine if IPv6 is enabled on the OCP cluster network

Related: OSPRH-8372