### PR TITLE
[18.0.0-proposed]Change weight assigned to podAntiAffinity to 100

### DIFF
--- a/modules/common/affinity/affinity.go
+++ b/modules/common/affinity/affinity.go
@@ -48,7 +48,7 @@ func DistributePods(
 						// https://github.com/kubernetes/api/blob/master/core/v1/well_known_labels.go#L20
 						TopologyKey: topologyKey,
 					},
-					Weight: 1,
+					Weight: 100,
 				},
 			},
 		},

--- a/modules/common/affinity/affinity_test.go
+++ b/modules/common/affinity/affinity_test.go
@@ -41,7 +41,7 @@ var affinityObj = &corev1.Affinity{
 					},
 					TopologyKey: "ThisTopologyKey",
 				},
-				Weight: 1,
+				Weight: 100,
 			},
 		},
 	},


### PR DESCRIPTION
The affinity weight ca be between 1 and 100 for each instance of the preferredDuringSchedulingIgnoredDuringExecution affinity type. When the scheduler finds nodes that meet all the other scheduling requirements of the Pod, the scheduler iterates through every preferred rule that the node satisfies and adds the value of the weight for that expression to a sum.

To make the pods better spread bump the weight to the max. Still the anti affinty is "this Pod should not run in an X if that X is already running one or more Pods that meet rule Y", which means if there are less nodes, but enough resources, the pods get scheduled there.

Related: https://issues.redhat.com/browse/OSPRH-8870

(cherry picked from commit c61e7505bdcf5d3e209d14ed1188ad596efc6157)