### PR TITLE
Requeue when TLS secret isn't found

### DIFF
--- a/modules/certmanager/test/functional/certmanager_test.go
+++ b/modules/certmanager/test/functional/certmanager_test.go
@@ -158,7 +158,7 @@ var _ = Describe("certmanager module", func() {
 			timeout,
 		)
 
-		_, err := c.CreateOrPatch(ctx, h, nil)
+		_, _, err := c.CreateOrPatch(ctx, h, nil)
 		Expect(err).ShouldNot(HaveOccurred())
 		cert := th.GetCert(names.CertName)
 		Expect(cert.Spec.CommonName).To(Equal("keystone-public-openstack.apps-crc.testing"))
@@ -188,7 +188,7 @@ var _ = Describe("certmanager module", func() {
 			timeout,
 		)
 
-		_, err := c.CreateOrPatch(ctx, h, nil)
+		_, _, err := c.CreateOrPatch(ctx, h, nil)
 		Expect(err).ShouldNot(HaveOccurred())
 		cert := th.GetCert(names.CertName)
 		Expect(cert).NotTo(BeNil())


### PR DESCRIPTION
closes OSPRH-7090 and partially OSPRH-9089

Jira: OSPRH-9089
Signed-off-by: Fabricio Aguiar <fabricio.aguiar@gmail.com>
(cherry picked from commit d1c32e5a90821fd6135649d1ab424a290ece19ef)
