### PR TITLE
Log 'not found' error instead of returning it alongside RequeueAfter

### DIFF
--- a/modules/common/configmap/configmap.go
+++ b/modules/common/configmap/configmap.go
@@ -29,6 +29,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -283,9 +284,10 @@ func VerifyConfigMap(
 	err := reader.Get(ctx, configMapName, configMap)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			log.FromContext(ctx).Info("ConfigMap not found", "configMapName", configMapName)
 			return "",
 				ctrl.Result{RequeueAfter: requeueTimeout},
-				fmt.Errorf("ConfigMap %s not found", configMapName)
+				nil
 		}
 		return "", ctrl.Result{}, fmt.Errorf("Get ConfigMap %s failed: %w", configMapName, err)
 	}

--- a/modules/common/secret/secret.go
+++ b/modules/common/secret/secret.go
@@ -34,6 +34,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // Hash function creates a hash of a Secret's Data and StringData fields and
@@ -420,9 +421,10 @@ func VerifySecret(
 	err := reader.Get(ctx, secretName, secret)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			log.FromContext(ctx).Info("Secret not found", "secretName", secretName)
 			return "",
 				ctrl.Result{RequeueAfter: requeueTimeout},
-				fmt.Errorf("Secret %s not found", secretName)
+				nil
 		}
 		return "", ctrl.Result{}, fmt.Errorf("Get secret %s failed: %w", secretName, err)
 	}


### PR DESCRIPTION
Returning a non-nil err with a RequeueAfter result causes k8s to discard the explicit requeue and wait much longer than desired.