### PR TITLE
Add message for waiting for TLS input resources

### DIFF
--- a/modules/common/condition/conditions.go
+++ b/modules/common/condition/conditions.go
@@ -318,6 +318,12 @@ const (
 	// AnsibleEEReadyErrorMessage
 	AnsibleEEReadyErrorMessage = "AnsibleEE error occurred %s"
 
+	//
+	// TLSInputReady condition messages
+	//
+	// TLSInputReadyWaitingMessage - Provides the message to clarify that TLS resources have not been generated yet
+	TLSInputReadyWaitingMessage = "TLSInput is missing: %s"
+
 	// TLSInputErrorMessage - Provides the message when there's error in provision of TLS sources
 	TLSInputErrorMessage = "TLSInput error occured in TLS sources %s"
 )


### PR DESCRIPTION
Given that we no longer return an error for k8s "not found" errors, we should add a message for TLSInput that can be used in `ctrlResult != ctrl.Result{}` situations (which indicate that a `Secret` is not found).