### PR TITLE
Fix TestValidateRoutedOverrides

### DIFF
--- a/modules/common/service/types_test.go
+++ b/modules/common/service/types_test.go
@@ -134,7 +134,7 @@ func TestValidateRoutedOverrides(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			g.Expect(ValidateRoutedOverrides(tt.basePath, tt.overrides)).To(Equal(tt.want))
+			g.Expect(ValidateRoutedOverrides(tt.basePath, tt.overrides)).To(ContainElements(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
ValidateRoutedOverrides does not guarantee a specific order of the returned ErrorList. As a result the "Multiple wrong override endpoints" sometimes fails even the expected errors are in the list. This changes to use ContainElements as it does not matter which order the errors are in the returned ErrorlList from ValidateRoutedOverrides.