### PR TITLE
Updating CodeQL workflow and adding a badge

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,24 +16,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language:
+          - language: go
+            build-mode: autobuild
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # lib-common
+[![CodeQL](https://github.com/openstack-k8s-operators/lib-common/actions/workflows/codeql.yml/badge.svg)](https://github.com/openstack-k8s-operators/lib-common/actions/workflows/codeql.yml)
 
 Common library for OpenStack K8s Operators.
 


### PR DESCRIPTION
Actions need to be updated, we can also drop the separate build action, as that is now rolled into the analyze action.

https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/ 