### PR TITLE
[18.0.0-proposed] [webhook] add ValidateDNS1123Label webhook func

### DIFF
--- a/modules/common/webhook/rfc.go
+++ b/modules/common/webhook/rfc.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2024 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateDNS1123Label - validates a list of strings are RFC 1123 label conform. Using the
+// correction parameter the validation.DNS1123LabelMaxLength (63) get reduced by the correction
+// value
+//
+// example usage:
+//
+//	ValidateDNS1123Label(<path>, {"foo", "bar"}, 5)
+func ValidateDNS1123Label(basePath *field.Path, keys []string, correction int) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for _, key := range keys {
+		msgs := validation.IsDNS1123Label(key)
+
+		maxLength := validation.DNS1123LabelMaxLength - correction
+
+		if correction > 0 && len(key) > maxLength {
+			msgs = append(msgs, validation.MaxLenError(maxLength))
+		}
+
+		for _, msg := range msgs {
+			allErrs = append(allErrs, field.Invalid(basePath.Key(key), key, msg))
+		}
+	}
+
+	return allErrs
+}

--- a/modules/common/webhook/rfc_test.go
+++ b/modules/common/webhook/rfc_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2024 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestValidateDNS1123Label(t *testing.T) {
+	tests := []struct {
+		name string
+		keys []string
+		corr int
+		want bool
+	}{
+		{
+			name: "valid name",
+			keys: []string{"foo123"},
+			corr: 0,
+			want: false,
+		},
+		{
+			name: "valid max lenth",
+			keys: []string{"foo-1234567890-1234567890-1234567890-1234567890-1234567890-1234"},
+			corr: 0,
+			want: false,
+		},
+		{
+			name: "invalid max lenth",
+			keys: []string{"foo-1234567890-1234567890-1234567890-1234567890-1234567890-1234567890"},
+			corr: 0,
+			want: true,
+		},
+		{
+			name: "invalid max lenth with correction",
+			keys: []string{"foo-1234567890-1234567890-1234567890-1234567890-1234567890-1234"},
+			corr: 5,
+			want: true,
+		},
+		{
+			name: "invalid char",
+			keys: []string{"foo_bar"},
+			corr: 0,
+			want: true,
+		},
+		{
+			name: "invalid multiple reasons",
+			keys: []string{"foo123", "foo-1234567890-1234567890-1234567890-1234567890-1234567890-1234567890", "foo_bar"},
+			corr: 0,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			p := field.NewPath("foo")
+
+			errs := ValidateDNS1123Label(p, tt.keys, tt.corr)
+			if tt.want {
+				g.Expect(errs).ToNot(BeEmpty())
+			} else {
+				g.Expect(errs).To(BeEmpty())
+			}
+		})
+	}
+}


### PR DESCRIPTION
validates a list of strings are RFC 1123 label conform. Using the correction parameter the validation.DNS1123LabelMaxLength (63) get reduced by the provided int to be control the max lenght.

Related: OSPRH-8063

Signed-off-by: Martin Schuppert <mschuppert@redhat.com>
(cherry picked from commit d524c2a3e1917dbc70a3b221a52f76fa6f000423)