### PR TITLE
Create getDNSClusterDomain

### DIFF
--- a/modules/common/clusterdns/clusterdns.go
+++ b/modules/common/clusterdns/clusterdns.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2024 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterdns
+
+// GetDNSClusterDomain - Return openshift dns Cluster Domain name
+func GetDNSClusterDomain() string {
+	// Currently this is hardcoded on the openshift dns operator, but
+	// this could change in the future, allowing the space to retrieve
+	// this information on a single point instead on each operator.
+	return "cluster.local"
+}


### PR DESCRIPTION
Openshift DNS creates it's records using the value in clusterDomain. This information could be customizable in the futre.

Currently on most of the operators they're using a hardcoded value, this function allows to all operators get this information from lib-common, and in case in the future this value is customizable we'd only need to change it here.