### PR TITLE
[test helper] fix nad test helper to return valid json config

### DIFF
--- a/modules/common/test/helpers/networkattachmentdefinition.go
+++ b/modules/common/test/helpers/networkattachmentdefinition.go
@@ -36,7 +36,7 @@ func (tc *TestHelper) CreateNetworkAttachmentDefinition(name types.NamespacedNam
 			Namespace: name.Namespace,
 		},
 		Spec: networkv1.NetworkAttachmentDefinitionSpec{
-			Config: "",
+			Config: `{}`,
 		},
 	}
 	gomega.Expect(tc.K8sClient.Create(tc.Ctx, instance)).Should(gomega.Succeed())


### PR DESCRIPTION
Related: https://issues.redhat.com/browse/OSPRH-8680