### PR TITLE
Add missing tags to []conditions which got reported by crd checker

### DIFF
--- a/modules/common/condition/types.go
+++ b/modules/common/condition/types.go
@@ -41,17 +41,50 @@ const (
 )
 
 // Type - A summarizing name for a given condition
+// ---
+// Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+// useful (see .node.status.conditions), the ability to deconflict is important.
+// The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
+// +kubebuilder:validation:MaxLength=316
 type Type string
 
 // Reason - Why a particular condition is true, false or unknown
+// reason contains a programmatic identifier indicating the reason for the condition's last transition.
+// Producers of specific condition types may define expected values and meanings for this field,
+// and whether the values are considered a guaranteed API.
+// The value should be a CamelCase string.
+// This field may not be empty.
+// +kubebuilder:validation:MaxLength=1024
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:Pattern=`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`
 type Reason string
 
-// Condition defines an observation of a API resource operational state.
+// Condition contains details for one aspect of the current state of this API Resource.
+// ---
+// This struct is intended for direct use as an array at the field path .status.conditions.  For example,
+//
+//	type FooStatus struct{
+//	    // Represents the observations of a foo's current state.
+//	    // Known .status.conditions.type are: "Available", "Progressing", and "Degraded"
+//	    // +patchMergeKey=type
+//	    // +patchStrategy=merge
+//	    // +listType=map
+//	    // +listMapKey=type
+//	    Conditions []condition.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+//
+//	    // other fields
+//	}
 type Condition struct {
 	// Type of condition in CamelCase.
+	// +required
+	// +kubebuilder:validation:Required
 	Type Type `json:"type"`
 
-	// Status of the condition, one of True, False, Unknown.
+	// status of the condition, one of True, False, Unknown.
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=True;False;Unknown
 	Status corev1.ConditionStatus `json:"status"`
 
 	// Severity provides a classification of Reason code, so the current situation is immediately
@@ -62,20 +95,30 @@ type Condition struct {
 	// For conditions where Status=Unknown or Status=True the Severity should be SeverityNone.
 	Severity Severity `json:"severity,omitempty"`
 
-	// Last time the condition transitioned from one status to another.
-	// This should be when the underlying condition changed. If that is not known, then using the time when
-	// the API field changed is acceptable.
+	// lastTransitionTime is the last time the condition transitioned from one status to another.
+	// This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=date-time
 	LastTransitionTime metav1.Time `json:"lastTransitionTime"`
 
 	// The reason for the condition's last transition in CamelCase.
+	// +optional
 	Reason Reason `json:"reason,omitempty"`
 
-	// A human readable message indicating details about the transition.
+	// message is a human readable message indicating details about the transition.
+	// This may be an empty string.
 	// +optional
+	// +kubebuilder:validation:MaxLength=32768
 	Message string `json:"message,omitempty"`
 }
 
 // Conditions provide observations of the operational state of a API resource.
+// +patchMergeKey=type
+// +patchStrategy=merge
+// +listType=map
+// +listMapKey=type
 type Conditions []Condition
 
 // conditionGroup defines a group of conditions with the same status and severity,


### PR DESCRIPTION
Adds the task which got reported by the crd checker recently added as a pre-commit validation.

Also syncs the validation of the conditon parameters with [1].

In a follow up, we should integrate the new ObservedGeneration for a condition [1]. The observedGeneration represents the .metadata.generation that the condition was set based upon.

[1] https://github.com/kubernetes/apimachinery/blob/release-1.29/pkg/apis/meta/v1/types.go#L1497
[1] https://github.com/kubernetes/apimachinery/blob/release-1.29/pkg/apis/meta/v1/types.go#L1518