### PR TITLE
[conditions] Reset conditions on Init()

### DIFF
--- a/modules/common/condition/funcs.go
+++ b/modules/common/condition/funcs.go
@@ -34,6 +34,7 @@ import (
 // Optional conditions list can be passed as parameter which allows to initialize
 // additional conditions at the beginning.
 func (conditions *Conditions) Init(cl *Conditions) {
+	conditions.Reset()
 	conditions.Set(UnknownCondition(ReadyCondition, RequestedReason, ReadyInitMessage))
 
 	// add all optional conditions if no not nil
@@ -100,6 +101,11 @@ func (conditions *Conditions) Remove(t Type) {
 	}
 
 	*conditions = newConditions
+}
+
+// Reset - removes all conditions
+func (conditions *Conditions) Reset() {
+	*conditions = Conditions{}
 }
 
 // Get returns the condition with the given type, if the condition does not exists,

--- a/modules/common/condition/funcs_test.go
+++ b/modules/common/condition/funcs_test.go
@@ -83,7 +83,10 @@ func TestInit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			conditions := Conditions{}
+			someCondition := TrueCondition("foo", "to be removed on Init()")
+			conditions := Conditions{
+				*someCondition,
+			}
 
 			conditions.Init(&tt.conditions)
 			g.Expect(conditions).To(haveSameConditionsOf(tt.want))
@@ -223,6 +226,38 @@ func TestRemove(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.conditions.Remove(tt.cType)
+			g.Expect(tt.expected).To(haveSameConditionsOf(tt.conditions))
+		})
+	}
+}
+
+func TestReset(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions Conditions
+		expected   Conditions
+	}{
+		{
+			name:       "empty",
+			conditions: Conditions{},
+			expected:   Conditions{},
+		},
+		{
+			name: "present",
+			conditions: CreateList(
+				unknownReady,
+				unknownA,
+				unknownB,
+			),
+			expected: Conditions{},
+		},
+	}
+
+	g := NewWithT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.conditions.Reset()
 			g.Expect(tt.expected).To(haveSameConditionsOf(tt.conditions))
 		})
 	}


### PR DESCRIPTION
Recently the operators changed to use CreateServiceReadyCondition instead of ExposeServiceReadyCondition. An update of an existing environment would result in the ExposeServiceReadyCondition to be never removed from the conditions list of a CR because the list is not reset on Init().

This adds a Reset() method and a call right at the start of Init().

Related: https://issues.redhat.com//browse/OSPRH-4164