### PR TITLE
[const] Adds TemplateParameters const

### DIFF
--- a/modules/common/const.go
+++ b/modules/common/const.go
@@ -30,4 +30,6 @@ const (
 	CustomPolicyFileName = "custom.yaml"
 	// InputHashName -Name of the hash of hashes of all resources used to indentify an input change
 	InputHashName = "input"
+	// TemplateParameters - Name of the key when storing a dump of the template parameters in the secret
+	TemplateParameters = "TemplateParameters"
 )


### PR DESCRIPTION
Adds TemplateParameters const, which reflects the name of the key when storing a dump of the template parameters in the secret.

Jira: https://issues.redhat.com/browse/OSPRH-13100