### PR TITLE
Improve error handling

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,8 @@ linters:
     - ginkgolinter
     - gofmt
     - govet
+    - errname
+    - err113
 linters-settings:
   revive:
     rules:

--- a/modules/certmanager/certificate.go
+++ b/modules/certmanager/certificate.go
@@ -262,7 +262,7 @@ func EnsureCert(
 	_, hasTLSKey := certSecret.Data["tls.key"]
 	_, hasTLSCert := certSecret.Data["tls.crt"]
 	if !hasTLSCert || !hasTLSKey {
-		err := fmt.Errorf("TLS secret %s in namespace %s does not have the fields tls.crt and tls.key", certSecretName, namespace)
+		err := fmt.Errorf("%w: TLS secret %s in namespace %s does not have the fields tls.crt and tls.key", util.ErrFieldNotFound, certSecretName, namespace)
 		return nil, ctrl.Result{}, err
 	}
 

--- a/modules/certmanager/issuer.go
+++ b/modules/certmanager/issuer.go
@@ -208,7 +208,7 @@ func GetIssuerByLabels(
 	}
 
 	if len(issuers.Items) > 1 {
-		return nil, fmt.Errorf("more then one issuer found in namespace %s", namespace)
+		return nil, fmt.Errorf("%w: more then one issuer found in namespace %s", util.ErrMoreThanOne, namespace)
 	}
 
 	if len(issuers.Items) == 0 {

--- a/modules/common/condition/conditions.go
+++ b/modules/common/condition/conditions.go
@@ -268,6 +268,9 @@ const (
 	// NetworkAttachmentsReadyErrorMessage
 	NetworkAttachmentsReadyErrorMessage = "NetworkAttachments error occurred %s"
 
+	// NetworkAttachmentsErrorMessage
+	NetworkAttachmentsErrorMessage = "NetworkAttachments error occurred not all pods have interfaces with ips as configured in NetworkAttachments: %s"
+
 	//
 	// CronJobReady condition messages
 	//

--- a/modules/common/configmap/configmap.go
+++ b/modules/common/configmap/configmap.go
@@ -44,7 +44,7 @@ func Hash(configMap *corev1.ConfigMap) (string, error) {
 	}
 
 	if configMap == nil {
-		return "", fmt.Errorf("nil ConfigMap doesn't have data to hash")
+		return "", fmt.Errorf("%w: nil ConfigMap doesn't have data to hash", util.ErrNotFound)
 	}
 
 	data := ConfigMapData{
@@ -297,7 +297,7 @@ func VerifyConfigMap(
 	for _, field := range expectedFields {
 		val, ok := configMap.Data[field]
 		if !ok {
-			err := fmt.Errorf("field %s not found in ConfigMap %s", field, configMapName)
+			err := fmt.Errorf("%w: field %s not found in ConfigMap %s", util.ErrFieldNotFound, field, configMapName)
 			return "", ctrl.Result{}, err
 		}
 		values = append(values, val)

--- a/modules/common/job/job.go
+++ b/modules/common/job/job.go
@@ -288,7 +288,7 @@ func (j *Job) waitOnJob(
 		if j.HasReachedLimit() {
 			errMsg = "Job has reached the specified backoff limit. Check job logs"
 		}
-		return ctrl.Result{}, k8s_errors.NewInternalError(errors.New(errMsg))
+		return ctrl.Result{}, k8s_errors.NewInternalError(errors.New(errMsg)) // nolint:err113
 	} else {
 		if existingJobHash != j.hash {
 			h.GetLogger().Info(

--- a/modules/common/pod/pod.go
+++ b/modules/common/pod/pod.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,7 +62,7 @@ func GetPodFQDNList(ctx context.Context, h *helper.Helper, namespace string, lab
 	for _, pod := range podList.Items {
 		// Check for pod.Spec.Hostname and Subdomain
 		if pod.Spec.Hostname == "" || pod.Spec.Subdomain == "" {
-			return nil, fmt.Errorf("Pod does not have the required Spec Hostname and Subdomain details to accurately form a FQDN")
+			return nil, fmt.Errorf("%w: Pod does not have the required Spec Hostname and Subdomain details to accurately form a FQDN", util.ErrNoPodSubdomain)
 		}
 		podSvcNames = append(podSvcNames, fmt.Sprintf("%s.%s", pod.Spec.Hostname, pod.Spec.Subdomain))
 	}

--- a/modules/common/probes/probes.go
+++ b/modules/common/probes/probes.go
@@ -19,6 +19,7 @@ package probes
 import (
 	"fmt"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -41,7 +42,7 @@ type ProbeConfig struct {
 func SetProbes(port int, disableNonTLSListeners bool, config ProbeConfig) (*v1.Probe, *v1.Probe, error) {
 
 	if port < 1 || port > 65535 {
-		return nil, nil, fmt.Errorf("invalid port: %d", port)
+		return nil, nil, fmt.Errorf("%w: %d", util.ErrInvalidPort, port)
 	}
 
 	var scheme v1.URIScheme

--- a/modules/common/secret/secret.go
+++ b/modules/common/secret/secret.go
@@ -47,7 +47,7 @@ func Hash(secret *corev1.Secret) (string, error) {
 	}
 
 	if secret == nil {
-		return "", fmt.Errorf("nil Secret doesn't have data to hash")
+		return "", fmt.Errorf("%w: nil Secret doesn't have data to hash", util.ErrNotFound)
 	}
 
 	data := SecretData{
@@ -434,7 +434,7 @@ func VerifySecret(
 	for _, field := range expectedFields {
 		val, ok := secret.Data[field]
 		if !ok {
-			err := fmt.Errorf("field %s not found in Secret %s", field, secretName)
+			err := fmt.Errorf("%w: field %s not found in Secret %s", util.ErrFieldNotFound, field, secretName)
 			return "", ctrl.Result{}, err
 		}
 		values = append(values, val)

--- a/modules/common/service/service.go
+++ b/modules/common/service/service.go
@@ -339,7 +339,7 @@ func (s *Service) CreateOrPatch(
 				s.externalIPs = append(s.externalIPs, ingr.IP)
 			}
 		} else {
-			return ctrl.Result{}, fmt.Errorf("%s LoadBalancer IP still pending", s.service.Name)
+			return ctrl.Result{}, fmt.Errorf("%w: %s LoadBalancer IP still pending", util.ErrResourceIsNotReady, s.service.Name)
 		}
 	}
 

--- a/modules/common/service/types.go
+++ b/modules/common/service/types.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -66,7 +67,7 @@ func (e *Endpoint) String() string {
 // Validate - validates if the endpoint is an allowed one.
 func (e *Endpoint) Validate() error {
 	if !slices.Contains([]Endpoint{EndpointInternal, EndpointPublic}, *e) {
-		return fmt.Errorf("invalid endpoint type: %s", e.String())
+		return fmt.Errorf("%w: %s", util.ErrInvalidEndpoint, e.String())
 	}
 	return nil
 }

--- a/modules/common/service/types_test.go
+++ b/modules/common/service/types_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
+
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -40,7 +42,7 @@ func TestEndpointValidate(t *testing.T) {
 		{
 			name: "Wrong endpoint",
 			e:    Endpoint("wrooong"),
-			want: fmt.Errorf("invalid endpoint type: wrooong"),
+			want: fmt.Errorf("%w: wrooong", util.ErrInvalidEndpoint),
 		},
 	}
 

--- a/modules/common/util/errors.go
+++ b/modules/common/util/errors.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"errors"
+)
+
+var (
+	// ErrResourceIsNotReady indicates that the resource is not ready
+	ErrResourceIsNotReady = errors.New("Resource is not ready")
+	// ErrInvalidPort indicates that the port is invalid
+	ErrInvalidPort = errors.New("invalid port")
+	// ErrNotFound indicates that the object was not found
+	ErrNotFound = errors.New("Object not found")
+	// ErrInvalidStatus indicates that the status is invalid
+	ErrInvalidStatus = errors.New("invalid status")
+	// ErrInvalidEndpoint indicates that the endpoint type is invalid
+	ErrInvalidEndpoint = errors.New("invalid endpoint type")
+	// ErrCannotUpdateObject indicates that the object cannot be updated
+	ErrCannotUpdateObject = errors.New("cannot update object")
+	// ErrFieldNotFound indicates that the field was not found in the Secret
+	ErrFieldNotFound = errors.New("field not found in Secret")
+	// ErrMoreThanOne indicates that only one should exist
+	ErrMoreThanOne = errors.New("Only one should exist")
+	// ErrNoPodSubdomain indicates that there is no Subdomain or Hostname
+	ErrNoPodSubdomain = errors.New("No Subdomain or Hostname")
+)

--- a/modules/openstack/domain.go
+++ b/modules/openstack/domain.go
@@ -38,7 +38,7 @@ func (o *OpenStack) CreateDomain(log logr.Logger, d Domain) (string, error) {
 		}
 		domainID = domain.ID
 	} else {
-		return domainID, fmt.Errorf("Multiple domains named \"%s\" found", d.Name)
+		return domainID, fmt.Errorf("Multiple domains named \"%s\" found", d.Name) // nolint:err113
 	}
 
 	return domainID, nil

--- a/modules/openstack/limits.go
+++ b/modules/openstack/limits.go
@@ -86,7 +86,7 @@ func (o *OpenStack) CreateLimit(
 		}
 		limitID = createdLimits[0].ID
 	} else {
-		return limitID, fmt.Errorf("multiple limits named \"%s\" found", l.ResourceName)
+		return limitID, fmt.Errorf("multiple limits named \"%s\" found", l.ResourceName) // nolint:err113
 	}
 
 	return limitID, nil
@@ -156,7 +156,7 @@ func (o *OpenStack) CreateOrUpdateRegisteredLimit(
 		}
 		limitID = createdLimits[0].ID
 	} else {
-		return limitID, fmt.Errorf("multiple limits named \"%s\" found", l.ResourceName)
+		return limitID, fmt.Errorf("multiple limits named \"%s\" found", l.ResourceName) // nolint:err113
 	}
 
 	return limitID, nil

--- a/modules/openstack/openstack.go
+++ b/modules/openstack/openstack.go
@@ -212,7 +212,7 @@ func GetAvailability(
 	} else if endpointInterface == string(service.EndpointPublic) {
 		availability = gophercloud.AvailabilityPublic
 	} else {
-		return availability, fmt.Errorf("endpoint interface %s not known", endpointInterface)
+		return availability, fmt.Errorf("endpoint interface %s not known", endpointInterface) // nolint:err113
 	}
 	return availability, nil
 }

--- a/modules/openstack/project.go
+++ b/modules/openstack/project.go
@@ -62,7 +62,7 @@ func (o *OpenStack) CreateProject(
 		}
 		projectID = project.ID
 	} else {
-		return projectID, fmt.Errorf("multiple projects named \"%s\" found", p.Name)
+		return projectID, fmt.Errorf("multiple projects named \"%s\" found", p.Name) // nolint:err113
 	}
 
 	return projectID, nil
@@ -84,9 +84,9 @@ func (o *OpenStack) GetProject(
 	}
 
 	if len(allProjects) == 0 {
-		return nil, fmt.Errorf("%s %s", projectName, ProjectNotFound)
+		return nil, fmt.Errorf("%s %s", projectName, ProjectNotFound) // nolint:err113
 	} else if len(allProjects) > 1 {
-		return nil, fmt.Errorf("multiple project named \"%s\" found", projectName)
+		return nil, fmt.Errorf("multiple project named \"%s\" found", projectName) // nolint:err113
 	}
 
 	return &allProjects[0], nil

--- a/modules/openstack/role.go
+++ b/modules/openstack/role.go
@@ -80,7 +80,7 @@ func (o *OpenStack) GetRole(
 	}
 
 	if len(allRoles) == 0 {
-		return nil, fmt.Errorf("%s %s", roleName, RoleNotFound)
+		return nil, fmt.Errorf("%s %s", roleName, RoleNotFound) // nolint:err113
 	}
 
 	return &allRoles[0], nil

--- a/modules/openstack/service.go
+++ b/modules/openstack/service.go
@@ -96,7 +96,7 @@ func (o *OpenStack) GetService(
 	}
 
 	if len(allServices) == 0 {
-		return nil, fmt.Errorf("%s %s", serviceName, ServiceNotFound)
+		return nil, fmt.Errorf("%s %s", serviceName, ServiceNotFound) // nolint:err113
 	}
 
 	return &allServices[0], nil

--- a/modules/openstack/user.go
+++ b/modules/openstack/user.go
@@ -94,9 +94,9 @@ func (o *OpenStack) GetUser(
 	}
 
 	if len(allUsers) == 0 {
-		return nil, fmt.Errorf("%s %s", userName, UserNotFound)
+		return nil, fmt.Errorf("%s %s", userName, UserNotFound) // nolint:err113
 	} else if len(allUsers) > 1 {
-		return nil, fmt.Errorf("multiple users named \"%s\" found", userName)
+		return nil, fmt.Errorf("multiple users named \"%s\" found", userName) // nolint:err113
 	}
 
 	return &allUsers[0], nil

--- a/modules/storage/ceph/funcs.go
+++ b/modules/storage/ceph/funcs.go
@@ -39,7 +39,7 @@ func GetPool(pools map[string]PoolSpec, service string) (string, error) {
 	case "glance":
 		return string(DefaultGlancePool), nil
 	default:
-		return string(CError), errors.New(string("No default pool found"))
+		return string(CError), errors.New(string("No default pool found")) // nolint:err113
 	}
 }
 

--- a/modules/test/crd.go
+++ b/modules/test/crd.go
@@ -66,7 +66,7 @@ func getDependencyVersion(moduleName string, goModPath string) (string, string, 
 		return name, version, nil
 	}
 
-	return name, "", fmt.Errorf("cannot find %s in %s file", moduleName, goModPath)
+	return name, "", fmt.Errorf("cannot find %s in %s file", moduleName, goModPath) // nolint:err113
 }
 
 // EncodePath returns the safe encoding of the given module path.
@@ -82,7 +82,7 @@ func encodePath(path string) (encoding string, err error) {
 		if r == '!' || r >= utf8.RuneSelf {
 			// This should be disallowed by CheckPath, but diagnose anyway.
 			// The correctness of the encoding loop below depends on it.
-			return "", fmt.Errorf("internal error: inconsistency in EncodePath")
+			return "", fmt.Errorf("internal error: inconsistency in EncodePath") // nolint:err113
 		}
 		if 'A' <= r && r <= 'Z' {
 			haveUpper = true


### PR DESCRIPTION
To follow best practices for error and exception handling in Go and to prevent regressions, err113 and gosec checks in golang-ci-linter are now enabled. Not all errors are corrected to not interfier to much with other repos.