### PR TITLE
Fix ListsMustHaveSSATags raised by crd-schema-checker

### DIFF
--- a/modules/common/service/types.go
+++ b/modules/common/service/types.go
@@ -215,6 +215,7 @@ type OverrideServiceSpec struct {
 	// cloud-provider does not support the feature."
 	// More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
 	// +optional
+	// +listType=atomic
 	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty" protobuf:"bytes,9,opt,name=loadBalancerSourceRanges"`
 
 	// externalName is the external reference that discovery mechanisms will


### PR DESCRIPTION
In openstack-operator, where we bump all the sub components CRDs, we are currently getting an error thrown by crd-schema-checker:

```
ERROR: "ListsMustHaveSSATags": crd/openstackcontrolplanes.core.openstack.org version/v1beta1 field/^.spec.designate.template.designateUnbound.override.services[*].spec.loadBalancerSourceRanges must set x-kubernetes-list-type
ERROR: "ListsMustHaveSSATags": crd/openstackcontrolplanes.core.openstack.org version/v1beta1 field/^.spec.designate.template.designateMdns.override.services[*].spec.loadBalancerSourceRanges must set x-kubernetes-list-type
ERROR: "ListsMustHaveSSATags": crd/openstackcontrolplanes.core.openstack.org version/v1beta1 field/^.spec.designate.template.designateBackendbind9.override.services[*].spec.loadBalancerSourceRanges must set x-kubernetes-list-type
```

I assume we hit this error with designate because is the first occurrence in the yaml `CRD`, but it's valid everywhere. This patch adds the `listType` to   `LoadBalancerSourceRanges` to make the check happy [1].

[1] https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/555-server-side-apply/README.md#lists