### PR TITLE
Add GetLabelSelector utility function

### DIFF
--- a/modules/common/labels/labels.go
+++ b/modules/common/labels/labels.go
@@ -86,3 +86,14 @@ func GetAppLabelSelector(
 ) metav1.LabelSelector {
 	return GetSingleLabelSelector(common.AppSelector, name)
 }
+
+// GetLabelSelector - utility function that returns a metav1.LabelSelector
+// based on the map[string]string that represents the k/v list passed to the
+// StatefulSet or Deployment as labelSelector
+func GetLabelSelector(
+	serviceLabels map[string]string,
+) metav1.LabelSelector {
+	return metav1.LabelSelector{
+		MatchLabels: serviceLabels,
+	}
+}


### PR DESCRIPTION
This function is used as utility to get the list of `matchLabels` used as `selector` for `Deployments` and `StatefulSet`. Most of the service operators use to pass a `serviceLabels map[string]string`, which is available in the controller(s). This function translates the data structure into a `metav1.LabelSelector` that we can easily plug to the existing `ensureTopology` logic provided by infra-operator [1].

[1] https://github.com/openstack-k8s-operators/infra-operator/blob/main/apis/topology/v1beta1/topology_types.go#L126