### PR TITLE
Do not use MustParse with wrong StorageRequest size

### DIFF
--- a/modules/common/webhook/storage_test.go
+++ b/modules/common/webhook/storage_test.go
@@ -65,6 +65,30 @@ func TestValidateStorageRequest(t *testing.T) {
 			wantErr:  false,
 			wantWarn: false,
 		},
+		{
+			name:     "req is a wrong string, want err",
+			req:      "foo",
+			min:      "500M",
+			err:      true,
+			wantErr:  true,
+			wantWarn: false,
+		},
+		{
+			name:     "min is a wrong string, want warn",
+			req:      "500M",
+			min:      "foo",
+			err:      false,
+			wantErr:  false,
+			wantWarn: true,
+		},
+		{
+			name:     "both are wrong strings, want err",
+			req:      "foo",
+			min:      "bar",
+			err:      true,
+			wantErr:  true,
+			wantWarn: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
In case of a wrong user input, the operator crashes without any chance to recover.
The `MustParse` implementation wraps the `ParseQuantity` function, that instead of `panic()` returns an error that can be easily handled at the operator level. This change does not alter the current behavior, but it adds a preliminary check that does not let the validation continue if the quantity is not valid. It also moves away from `MustParse` in favor of `ParseQuantity`. By doing this we can get a `webhook` feedback about the wrong quantity instead of checking the operators log and see the panic stacktrace.
This has been fixed in Glance and Swift [1][2].

[1] https://github.com/openstack-k8s-operators/glance-operator/pull/364
[2] https://github.com/openstack-k8s-operators/swift-operator/pull/190