### PR TITLE
Allow setting updateStrategy on DaemonSet

### DIFF
--- a/modules/common/daemonset/daemonset.go
+++ b/modules/common/daemonset/daemonset.go
@@ -63,6 +63,7 @@ func (d *DaemonSet) CreateOrPatch(
 		daemonset.Annotations = util.MergeStringMaps(daemonset.Annotations, d.daemonset.Annotations)
 		daemonset.Labels = util.MergeStringMaps(daemonset.Labels, d.daemonset.Labels)
 		daemonset.Spec.Template = d.daemonset.Spec.Template
+		daemonset.Spec.UpdateStrategy = d.daemonset.Spec.UpdateStrategy
 
 		err := controllerutil.SetControllerReference(h.GetBeforeObject(), daemonset, h.GetScheme())
 		if err != nil {


### PR DESCRIPTION
Currently on ovn-operators we may need to modify the updateStrategy for the daemonset, this is currently not supported, as if the updateStrategy is modified on the daemonset, this won't be reflected on the openshift cluster

Related: OSPRH-11636