### PR TITLE
[golangci] pin to v1.64.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ GINKGO ?= $(LOCALBIN)/ginkgo
 ## Tool Versions
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 GOTOOLCHAIN_VERSION ?= go1.21.0
+GOLANGCI_VERSION ?= v1.64.8
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29
@@ -123,7 +124,7 @@ gotest: get-ci-tools envtest ## Run go test via ci-tools script against code
 .PHONY: golangci
 golangci: get-ci-tools ## Run golangci-lint test via ci-tools script against code
 	for mod in $(shell find modules/ -maxdepth 1 -mindepth 1 -type d); do \
-		GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/golangci.sh ./$$mod || exit 1 ; \
+		GOLANGCI_TAG=$(GOLANGCI_VERSION) GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/golangci.sh ./$$mod || exit 1 ; \
 	done
 
 .PHONY: golint


### PR DESCRIPTION
fails with current released v2.0.0