### PR TITLE
[Deployment] Add PollRolloutStatus and poll deployment on updates

### DIFF
--- a/modules/common/deployment/deployment.go
+++ b/modules/common/deployment/deployment.go
@@ -18,28 +18,57 @@ package deployment
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // NewDeployment returns an initialized Deployment.
+//
+// Pass nil for pollingInterval and pollingTimeout to initialize with default.
 func NewDeployment(
 	deployment *appsv1.Deployment,
 	timeout time.Duration,
 ) *Deployment {
 	return &Deployment{
-		deployment: deployment,
-		timeout:    timeout,
+		deployment:          deployment,
+		timeout:             timeout,
+		rolloutPollInterval: ptr.To(DefaultPollInterval),
+		rolloutPollTimeout:  ptr.To(DefaultPollTimeout),
 	}
+}
+
+// SetRolloutPollInterval -
+func (d *Deployment) SetRolloutPollInterval(interval time.Duration) {
+	d.rolloutPollInterval = ptr.To(interval)
+}
+
+// GetRolloutPollInterval -
+func (d *Deployment) GetRolloutPollInterval() *time.Duration {
+	return d.rolloutPollInterval
+}
+
+// SetRolloutPollTimeout -
+func (d *Deployment) SetRolloutPollTimeout(timeout time.Duration) {
+	d.rolloutPollTimeout = ptr.To(timeout)
+}
+
+// GetRolloutPollTimeout -
+func (d *Deployment) GetRolloutPollTimeout() *time.Duration {
+	return d.rolloutPollTimeout
 }
 
 // CreateOrPatch - creates or patches a deployment, reconciles after Xs if object won't exist.
@@ -80,17 +109,114 @@ func (d *Deployment) CreateOrPatch(
 		}
 		return ctrl.Result{}, err
 	}
-	if op != controllerutil.OperationResultNone {
-		h.GetLogger().Info(fmt.Sprintf("Deployment %s - %s", deployment.Name, op))
-	}
-
 	// update the deployment object of the deployment type
-	d.deployment, err = GetDeploymentWithName(ctx, h, deployment.GetName(), deployment.GetNamespace())
-	if err != nil {
-		return ctrl.Result{}, err
+	d.deployment = deployment
+
+	h.GetLogger().Info(fmt.Sprintf("Deployment %s %s", deployment.Name, op))
+	// Only poll on Deployment updates, not on initial create.
+	if op != controllerutil.OperationResultCreated {
+		// only poll if replicas > 0
+		if d.deployment.Spec.Replicas != nil && *d.deployment.Spec.Replicas > 0 {
+			// Ignore context.DeadlineExceeded when PollUntilContextTimeout reached
+			// the poll timeout. d.rolloutStatus as information on the
+			// replica rollout, the consumer can evaluate the rolloutStatus and
+			// retry/reconcile until RolloutComplete, or ProgressDeadlineExceeded.
+			if err := d.PollRolloutStatus(ctx, h); err != nil && !errors.Is(err, context.DeadlineExceeded) &&
+				!strings.Contains(err.Error(), "would exceed context deadline") {
+				return ctrl.Result{}, fmt.Errorf("poll rollout error: %w", err)
+			}
+		}
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// PollRolloutStatus - will poll the deployment rollout to verify its status for Complet, Failed or polling until timeout.
+//
+// - Complete - all replicas updated using RolloutComplete()
+//
+// - Failed   - rollout of new config failed and the new pod is stuck in ProgressDeadlineExceeded using ProgressDeadlineExceeded()
+func (d *Deployment) PollRolloutStatus(
+	ctx context.Context,
+	h *helper.Helper,
+) error {
+	if d.rolloutPollInterval == nil {
+		d.rolloutPollInterval = ptr.To(DefaultPollInterval)
+	}
+	if d.rolloutPollTimeout == nil {
+		d.rolloutPollTimeout = ptr.To(DefaultPollTimeout)
+	}
+
+	err := wait.PollUntilContextTimeout(ctx, *d.rolloutPollInterval, *d.rolloutPollTimeout, true, func(ctx context.Context) (bool, error) {
+		// Fetch deployment object
+		depl, err := GetDeploymentWithName(ctx, h, d.deployment.Name, d.deployment.Namespace)
+		if err != nil {
+			return false, err
+		}
+		d.deployment = depl
+
+		// Check if rollout is complete
+		if Complete(d.deployment.Status, d.deployment.Generation) {
+			d.rolloutStatus = ptr.To(DeploymentPollCompleted)
+			d.rolloutMessage = fmt.Sprintf(DeploymentPollCompletedMessage, d.deployment.Name)
+			h.GetLogger().Info(d.rolloutMessage)
+			// If rollout is complete, return true to stop polling
+			return true, nil
+		}
+
+		// check if we already reached the ProgressDeadlineExceeded
+		if ok, msg := ProgressDeadlineExceeded(d.deployment.Status); ok {
+			d.rolloutStatus = ptr.To(DeploymentPollProgressDeadlineExceeded)
+			d.rolloutMessage = fmt.Sprintf(DeploymentPollProgressDeadlineExceededMessage, d.deployment.Name, msg)
+			// If rollout reached ProgressDeadlineExceeded, return true to stop polling
+			return true, nil
+		}
+
+		// If not yet complete, continue waiting
+		d.rolloutStatus = ptr.To(DeploymentPollProgressing)
+		d.rolloutMessage = fmt.Sprintf(DeploymentPollProgressingMessage, d.deployment.Name,
+			d.deployment.Status.UpdatedReplicas, d.deployment.Status.Replicas)
+		h.GetLogger().Info(*d.rolloutStatus)
+
+		return false, nil
+	})
+
+	return err
+}
+
+// RolloutComplete -
+func (d *Deployment) RolloutComplete() bool {
+	return d.GetRolloutStatus() != nil && *d.GetRolloutStatus() == DeploymentPollCompleted
+}
+
+// Complete -
+func Complete(status appsv1.DeploymentStatus, generation int64) bool {
+	return status.UpdatedReplicas == status.Replicas &&
+		status.Replicas == status.AvailableReplicas &&
+		status.ObservedGeneration == generation
+}
+
+// ProgressDeadlineExceeded -
+func ProgressDeadlineExceeded(status appsv1.DeploymentStatus) (bool, string) {
+	for _, condition := range status.Conditions {
+		if condition.Type == appsv1.DeploymentProgressing &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == DeploymentPollProgressDeadlineExceeded {
+			return true, condition.Message
+		}
+	}
+
+	return false, ""
+}
+
+// GetRolloutStatus - get rollout status of the deployment.
+func (d *Deployment) GetRolloutStatus() *string {
+	return d.rolloutStatus
+}
+
+// GetRolloutMessage - get rollout message of the deployment.
+func (d *Deployment) GetRolloutMessage() string {
+	return d.rolloutMessage
 }
 
 // Delete - delete a deployment.

--- a/modules/common/deployment/types.go
+++ b/modules/common/deployment/types.go
@@ -22,8 +22,31 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
+const (
+	// DeploymentPollCompleted -
+	DeploymentPollCompleted = "Completed"
+	// DeploymentPollCompletedMessage -
+	DeploymentPollCompletedMessage = "%s Completed"
+	// DeploymentPollProgressing -
+	DeploymentPollProgressing = "Progressing"
+	// DeploymentPollProgressingMessage -
+	DeploymentPollProgressingMessage = "%s - %d/%d replicas updated"
+	// DeploymentPollProgressDeadlineExceeded -
+	DeploymentPollProgressDeadlineExceeded = "ProgressDeadlineExceeded"
+	// DeploymentPollProgressDeadlineExceededMessage -
+	DeploymentPollProgressDeadlineExceededMessage = "%s ProgressDeadlineExceeded - %s"
+	// DefaultPollInterval -
+	DefaultPollInterval = 2 * time.Second
+	// DefaultPollTimeout -
+	DefaultPollTimeout = 20 * time.Second
+)
+
 // Deployment -
 type Deployment struct {
-	deployment *appsv1.Deployment
-	timeout    time.Duration
+	deployment          *appsv1.Deployment
+	timeout             time.Duration
+	rolloutStatus       *string
+	rolloutMessage      string
+	rolloutPollInterval *time.Duration
+	rolloutPollTimeout  *time.Duration
 }

--- a/modules/common/test/functional/deployment_test.go
+++ b/modules/common/test/functional/deployment_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2023 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package functional
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/deployment"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	replicas int32 = 3
+)
+
+func getExampleDeployment(namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(replicas),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-depl-pod",
+							Command: []string{
+								"/bin/bash",
+							},
+							Image: "test-container-image",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func runDeploymentSuccessfully(namespace string) (*deployment.Deployment, *appsv1.Deployment) {
+	exampleDepl := getExampleDeployment(namespace)
+	d := deployment.NewDeployment(exampleDepl, timeout)
+
+	_, err := d.CreateOrPatch(ctx, h)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	// a k8s Deployment is created with an controller reference
+	k8sDepl := d.GetDeployment()
+	Expect(k8sDepl.GetOwnerReferences()).To(HaveLen(1))
+	Expect(k8sDepl.GetOwnerReferences()[0]).To(HaveField("Name", h.GetBeforeObject().GetName()))
+	t := true
+	Expect(k8sDepl.GetOwnerReferences()[0]).To(HaveField("Controller", &t))
+
+	// Simulate that the Deployment replicas are ready
+	th.SimulateDeploymentReplicaReady(th.GetName(exampleDepl))
+
+	return d, th.GetDeployment(th.GetName(exampleDepl))
+}
+
+var _ = Describe("deployment package", func() {
+	var namespace string
+
+	BeforeEach(func() {
+		// NOTE(gibi): We need to create a unique namespace for each test run
+		// as namespaces cannot be deleted in a locally running envtest. See
+		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
+		namespace = uuid.New().String()
+		th.CreateNamespace(namespace)
+		// We still request the delete of the Namespace to properly cleanup if
+		// we run the test in an existing cluster.
+		DeferCleanup(th.DeleteNamespace, namespace)
+
+	})
+
+	It("defaults the poll interval and timeout if not explicite set", func() {
+		exampleDepl := getExampleDeployment(namespace)
+		d := deployment.NewDeployment(exampleDepl, timeout)
+
+		// defaults PollInterval
+		Expect(*d.GetRolloutPollInterval()).To(Equal(deployment.DefaultPollInterval))
+		Expect(*d.GetRolloutPollTimeout()).To(Equal(deployment.DefaultPollTimeout))
+
+		_, err := d.CreateOrPatch(ctx, h)
+
+		Expect(err).ShouldNot(HaveOccurred())
+		_, err = deployment.GetDeploymentWithName(ctx, h, exampleDepl.Name, namespace)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("use custom poll timeout/interval when set", func() {
+		exampleDepl := getExampleDeployment(namespace)
+		d := deployment.NewDeployment(exampleDepl, timeout)
+
+		// custom poll settings
+		customInterval := 10 * time.Second
+		customTimeout := 60 * time.Second
+
+		d.SetRolloutPollInterval(customInterval)
+		d.SetRolloutPollTimeout(customTimeout)
+
+		Expect(*d.GetRolloutPollInterval()).To(Equal(customInterval))
+		Expect(*d.GetRolloutPollTimeout()).To(Equal(customTimeout))
+	})
+
+	It("polls the deployment on an update and provides rollout status when progressing", func() {
+		exampleDepl := getExampleDeployment(namespace)
+		d := deployment.NewDeployment(exampleDepl, timeout)
+		_, err := d.CreateOrPatch(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		th.SimulateDeploymentReplicaReady(th.GetName(exampleDepl))
+
+		// update image of the deployment
+		exampleDepl.Spec.Template.Spec.Containers[0].Image = "new-test-container-image"
+		d = deployment.NewDeployment(exampleDepl, timeout)
+		_, err = d.CreateOrPatch(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// set deployment to progressing
+		th.SimulateDeploymentProgressing(th.GetName(exampleDepl))
+
+		// provides the rollout status after the poll timeout exceeded
+		_, err = d.CreateOrPatch(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(d.GetRolloutStatus()).NotTo(BeNil())
+		Expect(*d.GetRolloutStatus()).To(Equal(deployment.DeploymentPollProgressing))
+		Expect(d.GetRolloutMessage()).To(Equal(fmt.Sprintf("%s - 3/4 replicas updated", exampleDepl.Name)))
+
+		// set deployment to succeed
+		th.SimulateDeploymentReplicaReady(th.GetName(exampleDepl))
+
+		_, err = d.CreateOrPatch(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(d.GetRolloutStatus()).NotTo(BeNil())
+		Expect(*d.GetRolloutStatus()).To(Equal(deployment.DeploymentPollCompleted))
+		Expect(d.GetRolloutMessage()).To(Equal(fmt.Sprintf("%s Completed", exampleDepl.Name)))
+	})
+
+	It("polls the deployment on an update and provides rollout DeadlineExceeded status when reached", func() {
+		exampleDepl := getExampleDeployment(namespace)
+		d := deployment.NewDeployment(exampleDepl, timeout)
+		_, err := d.CreateOrPatch(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		th.SimulateDeploymentReplicaReady(th.GetName(exampleDepl))
+
+		// update image of the deployment
+		exampleDepl.Spec.Template.Spec.Containers[0].Image = "new-test-container-image"
+		d = deployment.NewDeployment(exampleDepl, timeout)
+		_, err = d.CreateOrPatch(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// set deployment to progressing
+		th.SimulateDeploymentProgressDeadlineExceeded(th.GetName(exampleDepl))
+
+		// provides the rollout status after the poll timeout exceeded
+		_, err = d.CreateOrPatch(ctx, h)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(d.GetRolloutStatus()).NotTo(BeNil())
+		Expect(*d.GetRolloutStatus()).To(Equal(deployment.DeploymentPollProgressDeadlineExceeded))
+		Expect(d.GetRolloutMessage()).To(ContainSubstring(fmt.Sprintf("%s ProgressDeadlineExceeded", exampleDepl.Name)))
+	})
+
+	It("DeleteDeployment deletes existing deployments", func() {
+		d, k8sDepl := runDeploymentSuccessfully(namespace)
+		// the job exists
+		th.GetDeployment(th.GetName(k8sDepl))
+
+		// assert that Delete deletes it properly so the k8sDeployment not found
+		// any more
+		Expect(d.Delete(ctx, h)).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := cClient.Get(ctx, th.GetName(k8sDepl), k8sDepl)
+			g.Expect(err).To(HaveOccurred())
+			var statusErr *k8s_errors.StatusError
+			g.Expect(errors.As(err, &statusErr)).To(BeTrue())
+			g.Expect(statusErr.Status().Reason).To(Equal(metav1.StatusReasonNotFound))
+		}, timeout, interval).Should(Succeed())
+	})
+
+})

--- a/modules/common/test/helpers/deployment.go
+++ b/modules/common/test/helpers/deployment.go
@@ -15,6 +15,7 @@ package helpers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/onsi/gomega"
@@ -59,8 +60,10 @@ func (tc *TestHelper) SimulateDeploymentAnyNumberReplicaReady(name types.Namespa
 	gomega.Eventually(func(g gomega.Gomega) {
 		deployment := tc.GetDeployment(name)
 
+		deployment.Status.AvailableReplicas = replica
 		deployment.Status.Replicas = replica
 		deployment.Status.ReadyReplicas = replica
+		deployment.Status.UpdatedReplicas = replica
 		deployment.Status.ObservedGeneration = deployment.Generation
 		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, deployment)).To(gomega.Succeed())
 	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
@@ -77,9 +80,15 @@ func (tc *TestHelper) SimulateDeploymentReplicaReady(name types.NamespacedName) 
 	gomega.Eventually(func(g gomega.Gomega) {
 		deployment := tc.GetDeployment(name)
 
+		deployment.Status.AvailableReplicas = *deployment.Spec.Replicas
 		deployment.Status.Replicas = *deployment.Spec.Replicas
 		deployment.Status.ReadyReplicas = *deployment.Spec.Replicas
+		deployment.Status.UpdatedReplicas = *deployment.Spec.Replicas
 		deployment.Status.ObservedGeneration = deployment.Generation
+
+		tc.Logger.Info("Simulated Deployment success", "ObservedGeneration", deployment.Status.ObservedGeneration)
+		tc.Logger.Info("Simulated Deployment success", "Generation", deployment.Generation)
+
 		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, deployment)).To(gomega.Succeed())
 	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
 
@@ -139,8 +148,10 @@ func (tc *TestHelper) SimulateDeploymentReadyWithPods(name types.NamespacedName,
 
 	gomega.Eventually(func(g gomega.Gomega) {
 		depl := tc.GetDeployment(name)
+		depl.Status.AvailableReplicas = *depl.Spec.Replicas
 		depl.Status.Replicas = *depl.Spec.Replicas
 		depl.Status.ReadyReplicas = *depl.Spec.Replicas
+		depl.Status.UpdatedReplicas = *depl.Spec.Replicas
 		depl.Status.ObservedGeneration = depl.Generation
 		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, depl)).To(gomega.Succeed())
 
@@ -156,4 +167,113 @@ func (tc *TestHelper) AssertDeploymentDoesNotExist(name types.NamespacedName) {
 		err := tc.K8sClient.Get(tc.Ctx, name, instance)
 		g.Expect(k8s_errors.IsNotFound(err)).To(gomega.BeTrue())
 	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
+}
+
+// SimulateDeploymentProgressing function retrieves the Deployment resource and
+// simulate that replicas are progressing
+// Example usage:
+//
+//	th.SimulateDeploymentProgressing(ironicNames.INAName)
+func (tc *TestHelper) SimulateDeploymentProgressing(name types.NamespacedName) {
+	gomega.Eventually(func(g gomega.Gomega) {
+		deployment := tc.GetDeployment(name)
+
+		deployment.Status.AvailableReplicas = *deployment.Spec.Replicas
+		deployment.Status.Replicas = *deployment.Spec.Replicas + 1
+		deployment.Status.ReadyReplicas = *deployment.Spec.Replicas
+		deployment.Status.UpdatedReplicas = *deployment.Spec.Replicas
+		deployment.Status.ObservedGeneration = deployment.Generation
+
+		/*
+			conditions:
+			- lastTransitionTime: "2025-03-11T10:53:00Z"
+			  lastUpdateTime: "2025-03-11T10:53:00Z"
+			  message: Deployment has minimum availability.
+			  reason: MinimumReplicasAvailable
+			  status: "True"
+			  type: Available
+			- lastTransitionTime: "2025-03-11T16:17:41Z"
+			  lastUpdateTime: "2025-03-11T16:27:31Z"
+			  message: ReplicaSet "keystone-869cb5d44c" is progressing.
+			  reason: ReplicaSetUpdated
+			  status: "True"
+			  type: Progressing
+		*/
+
+		deployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{
+				Message: "Deployment has minimum availability",
+				Reason:  "MinimumReplicasAvailable",
+				Status:  corev1.ConditionTrue,
+				Type:    appsv1.DeploymentAvailable,
+			},
+			{
+				Message: fmt.Sprintf("ReplicaSet \"%s-869cb5d44c\" is progressing.", deployment.Name),
+				Reason:  "ReplicaSetUpdated",
+				Status:  corev1.ConditionTrue,
+				Type:    appsv1.DeploymentProgressing,
+			}}
+
+		tc.Logger.Info("Simulated Deployment progressing", "ObservedGeneration", deployment.Status.ObservedGeneration)
+		tc.Logger.Info("Simulated Deployment progressing", "Generation", deployment.Generation)
+
+		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, deployment)).To(gomega.Succeed())
+	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
+
+	tc.Logger.Info("Simulated Deployment progressing", "on", name)
+}
+
+// SimulateDeploymentProgressDeadlineExceeded function retrieves the Deployment resource and
+// simulate that it hit ProgressDeadlineExceeded
+// Example usage:
+//
+//	th.SimulateDeploymentProgressDeadlineExceeded(ironicNames.INAName)
+func (tc *TestHelper) SimulateDeploymentProgressDeadlineExceeded(name types.NamespacedName) {
+	gomega.Eventually(func(g gomega.Gomega) {
+		deployment := tc.GetDeployment(name)
+
+		deployment.Status.AvailableReplicas = *deployment.Spec.Replicas
+		deployment.Status.Replicas = *deployment.Spec.Replicas + 1
+		deployment.Status.ReadyReplicas = *deployment.Spec.Replicas
+		deployment.Status.UpdatedReplicas = *deployment.Spec.Replicas
+		deployment.Status.ObservedGeneration = deployment.Generation
+		deployment.Status.UnavailableReplicas = 1
+
+		/*
+			conditions:
+			- lastTransitionTime: "2025-03-14T11:09:42Z"
+			  lastUpdateTime: "2025-03-14T11:09:42Z"
+			  message: Deployment has minimum availability.
+			  reason: MinimumReplicasAvailable
+			  status: "True"
+			  type: Available
+			- lastTransitionTime: "2025-03-18T13:49:18Z"
+			  lastUpdateTime: "2025-03-18T13:49:18Z"
+			  message: ReplicaSet "keystone-5d9c965546" has timed out progressing.
+			  reason: ProgressDeadlineExceeded
+			  status: "False"
+			  type: Progressing
+		*/
+
+		deployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{
+				Message: "Deployment has minimum availability",
+				Reason:  "MinimumReplicasAvailable",
+				Status:  corev1.ConditionTrue,
+				Type:    appsv1.DeploymentAvailable,
+			},
+			{
+				Message: fmt.Sprintf("ReplicaSet \"%s-869cb5d44c\" has timed out progressing.", deployment.Name),
+				Reason:  "ProgressDeadlineExceeded",
+				Status:  corev1.ConditionFalse,
+				Type:    appsv1.DeploymentProgressing,
+			}}
+
+		tc.Logger.Info("Simulated Deployment ProgressDeadlineExceeded", "ObservedGeneration", deployment.Status.ObservedGeneration)
+		tc.Logger.Info("Simulated Deployment ProgressDeadlineExceeded", "Generation", deployment.Generation)
+
+		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, deployment)).To(gomega.Succeed())
+	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
+
+	tc.Logger.Info("Simulated Deployment ProgressDeadlineExceeded", "on", name)
 }


### PR DESCRIPTION
When a deployment gets updated (config, image or changed spec) and the rollout results in the deployment to fail it should be reflected and the caller be able to evaluate. Currently if there is an issue like the above, the deployment rollout/update results in DeadlineExceed but it is not reflected in the service operators. Since the old config replicas are still up and healthy, the service is still functional with the old specs, but the rollout issue is not reflected.

This adds PollRolloutStatus() and calls it from CreateOrPatch() when the oparation != create.

Using rolloutPollInterval and rolloutPollTimeout, the caller can control the interval and timeout of one poll run which uses PollUntilContextTimeout().

The status and message of each run is reflected as d.rolloutStatus and d.rolloutMessage. Status can be Complete, Progressing and ProgressDeadlineExceeded. The message has a corresponding string to each of the status.

To note, the DeadlineExceeded from PollUntilContextTimeout() in CreateOrPatch() is ignored to allow the caller to reflect the rolleoutStatus/rolloutMessage in its DeploymentCondition and reconcile and trigger a new poll.

Jira: OSPRH-14472