### PR TITLE
[deployment/statefulset] add IsReady func

### DIFF
--- a/modules/common/deployment/deployment.go
+++ b/modules/common/deployment/deployment.go
@@ -127,3 +127,14 @@ func GetDeploymentWithName(
 
 	return depl, nil
 }
+
+// IsReady - validates when deployment is ready deployed to whats being requested
+// - the requested replicas in the spec matches the ReadyReplicas of the status
+// - the Status.Replicas match Status.ReadyReplicas. if a deployment update is in progress, Replicas > ReadyReplicas
+// - both when the Generatation of the object matches the ObservedGeneration of the Status
+func IsReady(deployment appsv1.Deployment) bool {
+	return deployment.Spec.Replicas != nil &&
+		*deployment.Spec.Replicas == deployment.Status.ReadyReplicas &&
+		deployment.Status.Replicas == deployment.Status.ReadyReplicas &&
+		deployment.Generation == deployment.Status.ObservedGeneration
+}

--- a/modules/common/statefulset/statefulset.go
+++ b/modules/common/statefulset/statefulset.go
@@ -138,3 +138,12 @@ func (s *StatefulSet) Delete(
 
 	return nil
 }
+
+// IsReady - validates when deployment is ready deployed to whats being requested
+// - the requested replicas in the spec matches the ReadyReplicas of the status
+// - both when the Generatation of the object matches the ObservedGeneration of the Status
+func IsReady(deployment appsv1.StatefulSet) bool {
+	return deployment.Spec.Replicas != nil &&
+		*deployment.Spec.Replicas == deployment.Status.ReadyReplicas &&
+		deployment.Generation == deployment.Status.ObservedGeneration
+}


### PR DESCRIPTION
Adds IsRead() for deployment and statefulset which can be used to validate when a deployment for the current Generation is fully provisioned and e.g. no rollout in progress.

Jira: OSPRH-14472