### PR TITLE
Fix ListsMustHaveSSATags raised by crd-schema-checker

### DIFF
--- a/modules/storage/storage.go
+++ b/modules/storage/storage.go
@@ -108,13 +108,16 @@ type Volume struct {
 type VolMounts struct {
 	// +kubebuilder:validation:type={PropagationEverywhere}
 	// Propagation defines which pod should mount the volume
+	// +listType=atomic
 	Propagation []PropagationType `json:"propagation,omitempty"`
 	// Label associated to a given extraMount
 	// +kubebuilder:validation:Optional
 	ExtraVolType ExtraVolType `json:"extraVolType,omitempty"`
 	// +kubebuilder:validation:Required
+	// +listType=atomic
 	Volumes []Volume `json:"volumes"`
 	// +kubebuilder:validation:Required
+	// +listType=atomic
 	Mounts []corev1.VolumeMount `json:"mounts"`
 }
 


### PR DESCRIPTION
In openstack-operator, where we bump all the sub components CRDs, we currently get an error thrown by crd-schema-checker:

```
> ERROR: "ListsMustHaveSSATags": crd/openstackcontrolplanes.core.openstack.org version/v1beta1 field/^.spec.keystone.template.extraMounts must set x-kubernetes-list-type
> ERROR: "ListsMustHaveSSATags": crd/openstackcontrolplanes.core.openstack.org version/v1beta1 field/^.spec.keystone.template.extraMounts[*].extraVol must set x-kubernetes-list-type
...
```

This patch adds the `listType` to the storage module extraMounts to make the check happy [1].

[1] https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/555-server-side-apply/README.md#lists