### PR TITLE
[18.0-fr2][deployment/statefulset] add IsReady func

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ GINKGO ?= $(LOCALBIN)/ginkgo
 ## Tool Versions
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 GOTOOLCHAIN_VERSION ?= go1.21.0
+GOLANGCI_VERSION ?= v1.64.8
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29
@@ -123,7 +124,7 @@ gotest: get-ci-tools envtest ## Run go test via ci-tools script against code
 .PHONY: golangci
 golangci: get-ci-tools ## Run golangci-lint test via ci-tools script against code
 	for mod in $(shell find modules/ -maxdepth 1 -mindepth 1 -type d); do \
-		GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/golangci.sh ./$$mod || exit 1 ; \
+		GOLANGCI_TAG=$(GOLANGCI_VERSION) GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/golangci.sh ./$$mod || exit 1 ; \
 	done
 
 .PHONY: golint

--- a/modules/common/deployment/deployment.go
+++ b/modules/common/deployment/deployment.go
@@ -127,3 +127,14 @@ func GetDeploymentWithName(
 
 	return depl, nil
 }
+
+// IsReady - validates when deployment is ready deployed to whats being requested
+// - the requested replicas in the spec matches the ReadyReplicas of the status
+// - the Status.Replicas match Status.ReadyReplicas. if a deployment update is in progress, Replicas > ReadyReplicas
+// - both when the Generatation of the object matches the ObservedGeneration of the Status
+func IsReady(deployment appsv1.Deployment) bool {
+	return deployment.Spec.Replicas != nil &&
+		*deployment.Spec.Replicas == deployment.Status.ReadyReplicas &&
+		deployment.Status.Replicas == deployment.Status.ReadyReplicas &&
+		deployment.Generation == deployment.Status.ObservedGeneration
+}

--- a/modules/common/statefulset/statefulset.go
+++ b/modules/common/statefulset/statefulset.go
@@ -138,3 +138,12 @@ func (s *StatefulSet) Delete(
 
 	return nil
 }
+
+// IsReady - validates when deployment is ready deployed to whats being requested
+// - the requested replicas in the spec matches the ReadyReplicas of the status
+// - both when the Generatation of the object matches the ObservedGeneration of the Status
+func IsReady(deployment appsv1.StatefulSet) bool {
+	return deployment.Spec.Replicas != nil &&
+		*deployment.Spec.Replicas == deployment.Status.ReadyReplicas &&
+		deployment.Generation == deployment.Status.ObservedGeneration
+}


### PR DESCRIPTION
Adds IsRead() for deployment and statefulset which can be used to validate when a deployment for the current Generation is fully provisioned and e.g. no rollout in progress.

Jira: OSPRH-14472