### PR TITLE
Add TenantID in AuthOpts

### DIFF
--- a/modules/openstack/openstack.go
+++ b/modules/openstack/openstack.go
@@ -47,6 +47,7 @@ type AuthOpts struct {
 	Username   string
 	Password   string
 	TenantName string
+	TenantID   string
 	DomainName string
 	Region     string
 	Scope      *gophercloud.AuthScope
@@ -70,6 +71,7 @@ func GetOpenStackProvider(
 		Username:         cfg.Username,
 		Password:         cfg.Password,
 		TenantName:       cfg.TenantName,
+		TenantID:         cfg.TenantID,
 		DomainName:       cfg.DomainName,
 	}
 	if cfg.Scope != nil {


### PR DESCRIPTION
It allows to use a Tenant from a different Domain than the User (see comment in gophercloud [0]).
Required by octavia-operator in [1]

[0] https://github.com/gophercloud/gophercloud/blob/849d9ea43b3c0659742ceea3fafb4f0f84b682ec/auth_options.go#L63-L66
[1] https://github.com/openstack-k8s-operators/octavia-operator/pull/478

JIRA: OSPRH-15809
