### PR TITLE
Add operator package

### DIFF
--- a/modules/common/operator/options.go
+++ b/modules/common/operator/options.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2025 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// SetManagerOptions - Get options from environment, validate and set controller manager options.
+func SetManagerOptions(options *ctrl.Options, setupLog logr.Logger) error {
+	leaseDuration, err := getEnvInDuration("LEASE_DURATION")
+	if err != nil {
+		return err
+	} else if leaseDuration != 0 {
+		setupLog.Info("manager configured with lease duration", "seconds", int(leaseDuration.Seconds()))
+		options.LeaseDuration = &leaseDuration
+	}
+
+	renewDeadline, err := getEnvInDuration("RENEW_DEADLINE")
+	if err != nil {
+		return err
+	} else if renewDeadline != 0 {
+		setupLog.Info("manager configured with renew deadline", "seconds", int(renewDeadline.Seconds()))
+		options.RenewDeadline = &renewDeadline
+	}
+
+	retryPeriod, err := getEnvInDuration("RETRY_PERIOD")
+	if err != nil {
+		return err
+	} else if retryPeriod != 0 {
+		setupLog.Info("manager configured with retry period", "seconds", int(retryPeriod.Seconds()))
+		options.RetryPeriod = &retryPeriod
+	}
+
+	return nil
+}
+
+func getEnvInDuration(envName string) (time.Duration, error) {
+	var durationInt int64
+	if durationStr := os.Getenv(envName); durationStr != "" {
+		var err error
+		if durationInt, err = strconv.ParseInt(durationStr, 10, 64); err != nil {
+			return 0, fmt.Errorf("unable to parse provided '%s', err: '%w'", envName, err)
+		}
+	}
+	return time.Duration(durationInt) * time.Second, nil
+}

--- a/modules/common/operator/options_test.go
+++ b/modules/common/operator/options_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2025 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestGetEnvInDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		envName  string
+		envValue string
+		wantErr  bool
+		expect   time.Duration
+	}{
+		{
+			name:     "Test valid",
+			envName:  "VALID",
+			envValue: "30",
+			wantErr:  false,
+			expect:   time.Duration(30 * time.Second),
+		},
+		{
+			name:     "Test invvalid",
+			envName:  "INVALID",
+			envValue: "3x0",
+			wantErr:  true,
+			expect:   time.Duration(60 * time.Second),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(tt.envName, tt.envValue)
+			res, err := getEnvInDuration(tt.envName)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("getEnvInDuration() expected error but got none")
+				}
+				return
+			} else if err != nil {
+				t.Errorf("getEnvInDuration() unexpected error: %v", err)
+				return
+			}
+			if res != tt.expect {
+				t.Errorf("getEnvInDuration() got = %v, want %v", res, tt.expect)
+			}
+		})
+	}
+}
+
+func TestSetManagerOptions(t *testing.T) {
+	var durationInt int64
+	var expectedValue time.Duration
+	setupLog := logr.New(nil)
+
+	tests := []struct {
+		name          string
+		leaseDuration string
+		renewDeadline string
+		retryPeriod   string
+		wantErr       bool
+	}{
+		{
+			name:          "Test SetOperatorOptions valid values",
+			leaseDuration: "137",
+			renewDeadline: "107",
+			retryPeriod:   "26",
+			wantErr:       false,
+		},
+		{
+			name:          "Test SetOperatorOptions invalid values",
+			leaseDuration: "foo",
+			renewDeadline: "bar",
+			retryPeriod:   "INVALID",
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("LEASE_DURATION", tt.leaseDuration)
+			t.Setenv("RENEW_DEADLINE", tt.renewDeadline)
+			t.Setenv("RETRY_PERIOD", tt.retryPeriod)
+			options := ctrl.Options{}
+			err := SetManagerOptions(&options, setupLog)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("SetOperatorOptions() expected error but got none")
+				}
+				return
+			} else if err != nil {
+				t.Errorf("SetOperatorOptions() unexpected error: %v", err)
+				return
+			}
+
+			durationInt, _ = strconv.ParseInt(tt.leaseDuration, 10, 64)
+			expectedValue = time.Duration(durationInt) * time.Second
+			if *options.LeaseDuration != expectedValue {
+				t.Errorf("SetOperatorOptions() got = %v, want %v", options.LeaseDuration, expectedValue)
+			}
+
+			durationInt, _ = strconv.ParseInt(tt.renewDeadline, 10, 64)
+			expectedValue = time.Duration(durationInt) * time.Second
+			if *options.RenewDeadline != expectedValue {
+				t.Errorf("SetOperatorOptions() got = %v, want %v", options.RenewDeadline, expectedValue)
+			}
+
+			durationInt, _ = strconv.ParseInt(tt.retryPeriod, 10, 64)
+			expectedValue = time.Duration(durationInt) * time.Second
+			if *options.RetryPeriod != expectedValue {
+				t.Errorf("SetOperatorOptions() got = %v, want %v", options.RetryPeriod, expectedValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add operators package, implements function setOperatorOptions which takes a pointer to controller options parses env vars and set's options.

Jira: OSPRH-16335