### PR TITLE
Add more annotations related functions

### DIFF
--- a/modules/common/annotations/network.go
+++ b/modules/common/annotations/network.go
@@ -19,6 +19,7 @@ package annotations
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 // NetworkAttachmentAnnot pod annotation for network-attachment-definition
@@ -53,4 +54,29 @@ func GetNADAnnotation(namespace string, nads []string) (map[string]string, error
 	}
 
 	return map[string]string{NetworkAttachmentAnnot: string(networks)}, nil
+}
+
+// GetBoolFromAnnotation - it returns a boolean from a string annotation
+// e.g. glance.openstack.org/wsgi: "true" returns true as a boolean type
+//
+// Cases covered by this function:
+// 1. the annotation does not exist -> false, false, nil
+// 2. the annotation exist and is not a valid boolean -> false, true, error
+// 3. the annotation exists and is a valid False bool -> false, true, nil
+// 4. the annotation exists and is a valid True bool -> true, true, nil
+func GetBoolFromAnnotation(
+	ann map[string]string,
+	key string,
+) (bool, bool, error) {
+	// Try to get the value associated to the annotation key
+	value, exists := ann[key]
+	if !exists {
+		return false, false, nil
+	}
+	result, err := strconv.ParseBool(value)
+	if err != nil {
+		// the annotation is not a valid boolean, return an error
+		return false, exists, err
+	}
+	return result, exists, nil
 }

--- a/modules/common/annotations/network_test.go
+++ b/modules/common/annotations/network_test.go
@@ -17,9 +17,8 @@ limitations under the License.
 package annotations
 
 import (
-	"testing"
-
 	. "github.com/onsi/gomega"
+	"testing"
 )
 
 func TestGetNADAnnotation(t *testing.T) {
@@ -60,4 +59,43 @@ func TestGetNADAnnotation(t *testing.T) {
 			g.Expect(networkAnnotation).To(BeEquivalentTo(tt.want))
 		})
 	}
+}
+
+func TestGetBoolFromAnnotation(t *testing.T) {
+	ann := map[string]string{}
+	testKey := "service.example.org/key"
+	var value bool
+	var exists bool
+	var err error
+
+	t.Run("", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Case 1: empty annotation map (the key does not exist)
+		value, exists, err = GetBoolFromAnnotation(ann, testKey)
+		g.Expect(exists).To(BeFalse())
+		g.Expect(value).To(BeFalse())
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Case 2: testKey exists but is not a valid bool
+		ann[testKey] = "foo"
+		value, exists, err = GetBoolFromAnnotation(ann, testKey)
+		g.Expect(value).To(BeFalse())
+		g.Expect(exists).To(BeTrue())
+		g.Expect(err).To(HaveOccurred())
+
+		// Case 3: testKey exists and is False
+		ann[testKey] = "false"
+		value, exists, err = GetBoolFromAnnotation(ann, testKey)
+		g.Expect(value).To(BeFalse())
+		g.Expect(exists).To(BeTrue())
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Case 4: testKey exists and is True
+		ann[testKey] = "true"
+		value, exists, err = GetBoolFromAnnotation(ann, testKey)
+		g.Expect(value).To(BeTrue())
+		g.Expect(exists).To(BeTrue())
+		g.Expect(err).ToNot(HaveOccurred())
+	})
 }


### PR DESCRIPTION
This patch improves the existing `annotations` module and provides a generic mechanism to get a particular `value` associated to a `key` from the annotations `map[string]string`. It also provides utilities to parse boolean based annotation values, used by service operators to set flags on their CR.

Jira: https://issues.redhat.com/browse/OSPRH-16261