### PR TITLE
Fix: update broken and outdated documentation URLs

### DIFF
--- a/modules/certmanager/test/functional/suite_test.go
+++ b/modules/certmanager/test/functional/suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.TODO())
 
 	// NOTE(mschuppert): CRD files in github.com/cert-manager/cert-manager/deploy/crds
-	// are templated and can not be be used as is. Rendered templates are in the
+	// are templated and can not be used as is. Rendered templates are in the
 	// openshift operator at github.com/openshift/cert-manager-operator/config/crd/bases
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/modules/common/route/types.go
+++ b/modules/common/route/types.go
@@ -71,14 +71,14 @@ type EmbeddedLabelsAnnotations struct {
 	// Map of string keys and values that can be used to organize and categorize
 	// (scope and select) objects. May match selectors of replication controllers
 	// and services.
-	// More info: http://kubernetes.io/docs/user-guide/labels
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 	// +optional
 	Labels map[string]string `json:"labels,omitempty" protobuf:"bytes,11,rep,name=labels"`
 
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set by external tools to store and retrieve arbitrary metadata. They are not
 	// queryable and should be preserved when modifying objects.
-	// More info: http://kubernetes.io/docs/user-guide/annotations
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty" protobuf:"bytes,12,rep,name=annotations"`
 }

--- a/modules/common/service/types.go
+++ b/modules/common/service/types.go
@@ -168,14 +168,14 @@ type EmbeddedLabelsAnnotations struct {
 	// Map of string keys and values that can be used to organize and categorize
 	// (scope and select) objects. May match selectors of replication controllers
 	// and services.
-	// More info: http://kubernetes.io/docs/user-guide/labels
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 	// +optional
 	Labels map[string]string `json:"labels,omitempty" protobuf:"bytes,11,rep,name=labels"`
 
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set by external tools to store and retrieve arbitrary metadata. They are not
 	// queryable and should be preserved when modifying objects.
-	// More info: http://kubernetes.io/docs/user-guide/annotations
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty" protobuf:"bytes,12,rep,name=annotations"`
 }

--- a/modules/common/util/template_util.go
+++ b/modules/common/util/template_util.go
@@ -145,7 +145,7 @@ var tmpl *template.Template
 
 // template function which allows to execute a template from within
 // a template file.
-// name - name of the template as defined with with `{{define "some-template"}}your template{{end}}
+// name - name of the template as defined with `{{define "some-template"}}your template{{end}}
 // data - data to pass into to render the template for all can use `.`
 func execTempl(name string, data interface{}) (string, error) {
 	buf := &bytes.Buffer{}

--- a/modules/openstack/openstack.go
+++ b/modules/openstack/openstack.go
@@ -155,7 +155,7 @@ func GetNovaOpenStackClient(
 	return &os, nil
 }
 
-// NewOpenStack creates a new new instance of the openstack identity struct from a config struct
+// NewOpenStack creates a new instance of the openstack identity struct from a config struct
 func NewOpenStack(
 	log logr.Logger,
 	cfg AuthOpts,

--- a/modules/test/apis/common.go
+++ b/modules/test/apis/common.go
@@ -26,7 +26,7 @@ type Handler struct {
 	// same request then the handler for the longer pattern will be executed.
 	// Using the same pattern in two handlers will cause a panic.
 	Pattern string
-	// Func the the function that handles the request by writing a response
+	// Func the function that handles the request by writing a response
 	Func func(http.ResponseWriter, *http.Request)
 }
 

--- a/modules/test/openshift_crds/cert-manager/v1/issuers.cert-manager.io-crd.yaml
+++ b/modules/test/openshift_crds/cert-manager/v1/issuers.cert-manager.io-crd.yaml
@@ -62,7 +62,7 @@ spec:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
                     enableDurationFeature:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it will create an error on the Order. Defaults to false.
                       type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.

--- a/modules/test/openshift_crds/route/v1/route_crd.yaml
+++ b/modules/test/openshift_crds/route/v1/route_crd.yaml
@@ -217,7 +217,7 @@ spec:
                                       description: value specifies a header value.
                                         Dynamic values can be added. The value will
                                         be interpreted as an HAProxy format string
-                                        as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
+                                        as defined in https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
                                         and may use HAProxy's %[] syntax and otherwise
                                         must be a valid HTTP header value as defined
                                         in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.
@@ -291,7 +291,7 @@ spec:
                         - message: Either the header value provided is not in correct
                             format or the sample fetcher/converter specified is not
                             allowed. The dynamic header value will be interpreted
-                            as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
+                            as an HAProxy format string as defined in https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
                             and may use HAProxy's %[] syntax and otherwise must be
                             a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.
                             Sample fetchers allowed are req.hdr, ssl_c_der. Converters
@@ -333,7 +333,7 @@ spec:
                                       description: value specifies a header value.
                                         Dynamic values can be added. The value will
                                         be interpreted as an HAProxy format string
-                                        as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
+                                        as defined in https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
                                         and may use HAProxy's %[] syntax and otherwise
                                         must be a valid HTTP header value as defined
                                         in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.
@@ -407,7 +407,7 @@ spec:
                         - message: Either the header value provided is not in correct
                             format or the sample fetcher/converter specified is not
                             allowed. The dynamic header value will be interpreted
-                            as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
+                            as an HAProxy format string as defined in https://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
                             and may use HAProxy's %[] syntax and otherwise must be
                             a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.
                             Sample fetchers allowed are res.hdr, ssl_c_der. Converters


### PR DESCRIPTION
- Replace deprecated Kubernetes user-guide URLs with current documentation paths
- Update HAProxy documentation links from HTTP to HTTPS

Fixes 404 error and ensures all documentation links point to current, valid URLs.

Asssited-by: claude-4-sonnet