### PR TITLE
[18.0-fr3] Empty nad spec backport

### DIFF
--- a/modules/common/networkattachment/networkattachment_test.go
+++ b/modules/common/networkattachment/networkattachment_test.go
@@ -184,6 +184,15 @@ func TestEnsureNetworksAnnotation(t *testing.T) {
 			want:    map[string]string{networkv1.NetworkAttachmentAnnot: "[]"},
 		},
 		{
+			name: "Empty NetworkAttachmentDefinition spec",
+			nadList: []networkv1.NetworkAttachmentDefinition{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "one", Namespace: "foo"},
+				},
+			},
+			want: map[string]string{networkv1.NetworkAttachmentAnnot: "[{\"name\":\"one\",\"namespace\":\"foo\",\"interface\":\"one\"}]"},
+		},
+		{
 			name: "Single network",
 			nadList: []networkv1.NetworkAttachmentDefinition{
 				{


### PR DESCRIPTION
backport of https://github.com/openstack-k8s-operators/lib-common/pull/636

Jira: https://issues.redhat.com/browse/OSPRH-19873