### PR TITLE
[template]Make execTempl non-global

### DIFF
--- a/modules/common/util/template_util.go
+++ b/modules/common/util/template_util.go
@@ -142,19 +142,6 @@ func ExecuteTemplate(templateFile string, data interface{}) (string, error) {
 	return renderedTemplate, nil
 }
 
-// template functions
-var tmpl *template.Template
-
-// template function which allows to execute a template from within
-// a template file.
-// name - name of the template as defined with `{{define "some-template"}}your template{{end}}
-// data - data to pass into to render the template for all can use `.`
-func execTempl(name string, data interface{}) (string, error) {
-	buf := &bytes.Buffer{}
-	err := tmpl.ExecuteTemplate(buf, name, data)
-	return buf.String(), err
-}
-
 // template function to indent the template with n tabs
 func indent(n int, in string) string {
 	var out string
@@ -231,6 +218,18 @@ func lower(s string) string {
 // ExecuteTemplateData creates a template from string and
 // execute it with the specified data
 func ExecuteTemplateData(templateData string, data interface{}) (string, error) {
+	// template functions
+	var tmpl *template.Template
+
+	// template function which allows to execute a template from within
+	// a template file.
+	// name - name of the template as defined with `{{define "some-template"}}your template{{end}}
+	// data - data to pass into to render the template for all can use `.`
+	execTempl := func(name string, data interface{}) (string, error) {
+		buf := &bytes.Buffer{}
+		err := tmpl.ExecuteTemplate(buf, name, data)
+		return buf.String(), err
+	}
 
 	var buff bytes.Buffer
 	var err error


### PR DESCRIPTION
There was a package global variable in template_utils to implement execting templating within the template file itself. This global made it possible that two such templating function within the same process interfere via that global leading to intermittent errors like

```
  "error": "template: tmp:365:12: executing \"tmp\" at <execTempl \"nova-template\" .>: error calling execTempl: template: no template \"nova-template\" associated with template \"tmp\"
```
during parallel reconciliation with the same manager.

This makes the shared variable a local variable for each template execution calls.