### PR TITLE
Make ssl.conf a Go template with overridable cipher suite and protocol

### DIFF
--- a/modules/common/util/template_util_test.go
+++ b/modules/common/util/template_util_test.go
@@ -680,14 +680,29 @@ baz=1
 }
 
 func TestGetCommonTemplates(t *testing.T) {
-	t.Run("Returns ssl.conf", func(t *testing.T) {
+	t.Run("Returns ssl.conf with defaults", func(t *testing.T) {
 		g := NewWithT(t)
 
 		result, err := GetCommonTemplates(map[string]interface{}{})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(result).To(HaveKey("ssl.conf"))
 		g.Expect(result["ssl.conf"]).To(ContainSubstring("mod_ssl"))
-		g.Expect(result["ssl.conf"]).To(ContainSubstring("SSLProtocol"))
-		g.Expect(result["ssl.conf"]).To(ContainSubstring("SSLCipherSuite"))
+		g.Expect(result["ssl.conf"]).To(ContainSubstring("SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5:!RC4:!3DES"))
+		g.Expect(result["ssl.conf"]).To(ContainSubstring("SSLProtocol all -SSLv2 -SSLv3 -TLSv1"))
+	})
+
+	t.Run("SSLCipherSuite and SSLProtocol can be overridden", func(t *testing.T) {
+		g := NewWithT(t)
+
+		result, err := GetCommonTemplates(map[string]interface{}{
+			"SSLCipherSuite": "ECDHE+AESGCM:ECDHE+CHACHA20",
+			"SSLProtocol":    "-all +TLSv1.3",
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(HaveKey("ssl.conf"))
+		g.Expect(result["ssl.conf"]).To(ContainSubstring("SSLCipherSuite ECDHE+AESGCM:ECDHE+CHACHA20"))
+		g.Expect(result["ssl.conf"]).To(ContainSubstring("SSLProtocol -all +TLSv1.3"))
+		g.Expect(result["ssl.conf"]).NotTo(ContainSubstring("HIGH:MEDIUM"))
+		g.Expect(result["ssl.conf"]).NotTo(ContainSubstring("all -SSLv2"))
 	})
 }

--- a/modules/common/util/templates/common/config/ssl.conf
+++ b/modules/common/util/templates/common/config/ssl.conf
@@ -15,7 +15,7 @@
   SSLHonorCipherOrder On
   SSLUseStapling Off
   SSLStaplingCache "shmcb:/run/httpd/ssl_stapling(32768)"
-  SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5:!RC4:!3DES
-  SSLProtocol all -SSLv2 -SSLv3 -TLSv1
+  SSLCipherSuite {{ or (index . "SSLCipherSuite") "HIGH:MEDIUM:!aNULL:!MD5:!RC4:!3DES" }}
+  SSLProtocol {{ or (index . "SSLProtocol") "all -SSLv2 -SSLv3 -TLSv1" }}
   SSLOptions StdEnvVars
 </IfModule>


### PR DESCRIPTION
Whether we decide to keep hardcoded default values that perform a graceful downgrade when a protocol or cipher suite cannot be negotiated, or inject the lines proposed by this patch as a `template` from `openstack-operator`, this change does not introduce any regression to the current model.

Jira: [OSPRH-30239](https://redhat.atlassian.net/browse/OSPRH-30239)
Jira: [OSPRH-31347](https://redhat.atlassian.net/browse/OSPRH-31347)