### PR TITLE
Tighten common ssl.conf defaults

### DIFF
--- a/modules/common/util/templates/common/config/ssl.conf
+++ b/modules/common/util/templates/common/config/ssl.conf
@@ -15,7 +15,7 @@
   SSLHonorCipherOrder On
   SSLUseStapling Off
   SSLStaplingCache "shmcb:/run/httpd/ssl_stapling(32768)"
-  SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5:!RC4:!3DES
-  SSLProtocol all -SSLv2 -SSLv3 -TLSv1
+  SSLCipherSuite ECDHE+AESGCM:DHE+AESGCM:!aNULL:!MD5:!RC4:!3DES
+  SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
   SSLOptions StdEnvVars
 </IfModule>


### PR DESCRIPTION
Prefer forward-secret GCM ciphers and disable TLSv1.1 in the shared Apache SSL template so operators consuming lib-common inherit stronger defaults.

jira: OSPRH-29016