### PR TITLE
Require all pods updated before reporting IsReady

### DIFF
--- a/modules/common/deployment/deployment.go
+++ b/modules/common/deployment/deployment.go
@@ -132,10 +132,12 @@ func GetDeploymentWithName(
 // IsReady - validates when deployment is ready deployed to whats being requested
 // - the requested replicas in the spec matches the ReadyReplicas of the status
 // - the Status.Replicas match Status.ReadyReplicas. if a deployment update is in progress, Replicas > ReadyReplicas
+// - all pods run the current spec (UpdatedReplicas == requested replicas)
 // - both when the Generatation of the object matches the ObservedGeneration of the Status
 func IsReady(deployment appsv1.Deployment) bool {
 	return deployment.Spec.Replicas != nil &&
 		*deployment.Spec.Replicas == deployment.Status.ReadyReplicas &&
+		*deployment.Spec.Replicas == deployment.Status.UpdatedReplicas &&
 		deployment.Status.Replicas == deployment.Status.ReadyReplicas &&
 		deployment.Generation == deployment.Status.ObservedGeneration
 }

--- a/modules/common/statefulset/statefulset.go
+++ b/modules/common/statefulset/statefulset.go
@@ -152,9 +152,11 @@ func (s *StatefulSet) Delete(
 
 // IsReady - validates when deployment is ready deployed to whats being requested
 // - the requested replicas in the spec matches the ReadyReplicas of the status
+// - all pods run the current spec (UpdatedReplicas == requested replicas)
 // - both when the Generatation of the object matches the ObservedGeneration of the Status
 func IsReady(deployment appsv1.StatefulSet) bool {
 	return deployment.Spec.Replicas != nil &&
 		*deployment.Spec.Replicas == deployment.Status.ReadyReplicas &&
+		*deployment.Spec.Replicas == deployment.Status.UpdatedReplicas &&
 		deployment.Generation == deployment.Status.ObservedGeneration
 }


### PR DESCRIPTION
During rolling updates, ReadyReplicas can match the desired count while UpdatedReplicas lags behind — old pods are still ready but running stale config. Add UpdatedReplicas == Spec.Replicas to both deployment.IsReady() and statefulset.IsReady() so consumers (e.g. transport secret rotation guards) don't act on stale readiness.