### PR TITLE
Default ImagePullPolicy to IfNotPresent for all workload helpers

### DIFF
--- a/modules/common/cronjob/cronjob.go
+++ b/modules/common/cronjob/cronjob.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/pod"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -52,6 +53,7 @@ func (cj *CronJob) CreateOrPatch(
 
 	op, err := controllerutil.CreateOrPatch(ctx, h.GetClient(), cronjob, func() error {
 		cronjob.Spec = cj.cronjob.Spec
+		pod.SetPullPolicyDefaults(&cronjob.Spec.JobTemplate.Spec.Template.Spec)
 		err := controllerutil.SetControllerReference(h.GetBeforeObject(), cronjob, h.GetScheme())
 		if err != nil {
 			return err

--- a/modules/common/daemonset/daemonset.go
+++ b/modules/common/daemonset/daemonset.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/pod"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	appsv1 "k8s.io/api/apps/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -64,6 +65,7 @@ func (d *DaemonSet) CreateOrPatch(
 		daemonset.Annotations = util.MergeStringMaps(daemonset.Annotations, d.daemonset.Annotations)
 		daemonset.Labels = util.MergeStringMaps(daemonset.Labels, d.daemonset.Labels)
 		daemonset.Spec.Template = d.daemonset.Spec.Template
+		pod.SetPullPolicyDefaults(&daemonset.Spec.Template.Spec)
 		daemonset.Spec.UpdateStrategy = d.daemonset.Spec.UpdateStrategy
 
 		err := controllerutil.SetControllerReference(h.GetBeforeObject(), daemonset, h.GetScheme())

--- a/modules/common/deployment/deployment.go
+++ b/modules/common/deployment/deployment.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/pod"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	appsv1 "k8s.io/api/apps/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -64,6 +65,7 @@ func (d *Deployment) CreateOrPatch(
 		deployment.Annotations = util.MergeStringMaps(deployment.Annotations, d.deployment.Annotations)
 		deployment.Labels = util.MergeStringMaps(deployment.Labels, d.deployment.Labels)
 		deployment.Spec.Template = d.deployment.Spec.Template
+		pod.SetPullPolicyDefaults(&deployment.Spec.Template.Spec)
 		deployment.Spec.Replicas = d.deployment.Spec.Replicas
 		deployment.Spec.Strategy = d.deployment.Spec.Strategy
 

--- a/modules/common/job/job.go
+++ b/modules/common/job/job.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/pod"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -128,6 +129,8 @@ func (j *Job) DoJob(
 ) (ctrl.Result, error) {
 	var ctrlResult ctrl.Result
 	var err error
+
+	pod.SetPullPolicyDefaults(&j.expectedJob.Spec.Template.Spec)
 
 	// We intentionally only include the PodTemplate Spec in the hash of the Job.
 	// PodTemplate metadata is excluded as it can be altered by k8s (labels specifically).

--- a/modules/common/pod/pod.go
+++ b/modules/common/pod/pod.go
@@ -29,6 +29,23 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+// SetPullPolicyDefaults sets ImagePullPolicy to PullIfNotPresent on every
+// container in the PodSpec that does not already have an explicit policy.
+// Without an explicit policy, Kubernetes defaults to PullAlways when the
+// image tag is "latest" or unset.
+func SetPullPolicyDefaults(podSpec *corev1.PodSpec) {
+	for i := range podSpec.InitContainers {
+		if podSpec.InitContainers[i].ImagePullPolicy == "" {
+			podSpec.InitContainers[i].ImagePullPolicy = corev1.PullIfNotPresent
+		}
+	}
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].ImagePullPolicy == "" {
+			podSpec.Containers[i].ImagePullPolicy = corev1.PullIfNotPresent
+		}
+	}
+}
+
 // GetPodListWithLabel - Get all pods in namespace of the obj matching label selector
 func GetPodListWithLabel(
 	ctx context.Context,

--- a/modules/common/pod/pod_test.go
+++ b/modules/common/pod/pod_test.go
@@ -1,0 +1,82 @@
+package pod
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestSetPullPolicyDefaults_EmptyPolicy(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{
+			{Name: "main", Image: "myimage:latest"},
+		},
+		InitContainers: []corev1.Container{
+			{Name: "init", Image: "initimage:latest"},
+		},
+	}
+	SetPullPolicyDefaults(podSpec)
+	if podSpec.Containers[0].ImagePullPolicy != corev1.PullIfNotPresent {
+		t.Errorf("expected PullIfNotPresent, got %v", podSpec.Containers[0].ImagePullPolicy)
+	}
+	if podSpec.InitContainers[0].ImagePullPolicy != corev1.PullIfNotPresent {
+		t.Errorf("expected PullIfNotPresent for init container, got %v", podSpec.InitContainers[0].ImagePullPolicy)
+	}
+}
+
+func TestSetPullPolicyDefaults_ExplicitPolicyPreserved(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{
+			{Name: "always", Image: "img:latest", ImagePullPolicy: corev1.PullAlways},
+			{Name: "never", Image: "img:v1", ImagePullPolicy: corev1.PullNever},
+			{Name: "ifnotpresent", Image: "img:v2", ImagePullPolicy: corev1.PullIfNotPresent},
+		},
+		InitContainers: []corev1.Container{
+			{Name: "init-always", Image: "img:latest", ImagePullPolicy: corev1.PullAlways},
+		},
+	}
+	SetPullPolicyDefaults(podSpec)
+	if podSpec.Containers[0].ImagePullPolicy != corev1.PullAlways {
+		t.Errorf("expected PullAlways preserved, got %v", podSpec.Containers[0].ImagePullPolicy)
+	}
+	if podSpec.Containers[1].ImagePullPolicy != corev1.PullNever {
+		t.Errorf("expected PullNever preserved, got %v", podSpec.Containers[1].ImagePullPolicy)
+	}
+	if podSpec.Containers[2].ImagePullPolicy != corev1.PullIfNotPresent {
+		t.Errorf("expected PullIfNotPresent preserved, got %v", podSpec.Containers[2].ImagePullPolicy)
+	}
+	if podSpec.InitContainers[0].ImagePullPolicy != corev1.PullAlways {
+		t.Errorf("expected PullAlways preserved for init container, got %v", podSpec.InitContainers[0].ImagePullPolicy)
+	}
+}
+
+func TestSetPullPolicyDefaults_MixedPolicies(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{
+			{Name: "set", Image: "img:v1", ImagePullPolicy: corev1.PullAlways},
+			{Name: "unset", Image: "img:latest"},
+		},
+		InitContainers: []corev1.Container{
+			{Name: "init-set", Image: "img:v1", ImagePullPolicy: corev1.PullNever},
+			{Name: "init-unset", Image: "img:latest"},
+		},
+	}
+	SetPullPolicyDefaults(podSpec)
+	if podSpec.Containers[0].ImagePullPolicy != corev1.PullAlways {
+		t.Errorf("expected PullAlways preserved, got %v", podSpec.Containers[0].ImagePullPolicy)
+	}
+	if podSpec.Containers[1].ImagePullPolicy != corev1.PullIfNotPresent {
+		t.Errorf("expected PullIfNotPresent defaulted, got %v", podSpec.Containers[1].ImagePullPolicy)
+	}
+	if podSpec.InitContainers[0].ImagePullPolicy != corev1.PullNever {
+		t.Errorf("expected PullNever preserved, got %v", podSpec.InitContainers[0].ImagePullPolicy)
+	}
+	if podSpec.InitContainers[1].ImagePullPolicy != corev1.PullIfNotPresent {
+		t.Errorf("expected PullIfNotPresent defaulted, got %v", podSpec.InitContainers[1].ImagePullPolicy)
+	}
+}
+
+func TestSetPullPolicyDefaults_NoContainers(t *testing.T) {
+	podSpec := &corev1.PodSpec{}
+	SetPullPolicyDefaults(podSpec)
+}

--- a/modules/common/statefulset/statefulset.go
+++ b/modules/common/statefulset/statefulset.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/pod"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	appsv1 "k8s.io/api/apps/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -76,6 +77,8 @@ func (s *StatefulSet) CreateOrPatch(
 		// any new Kubernetes fields are picked up automatically without
 		// needing to add individual field copies.
 		statefulset.Spec = s.statefulset.Spec
+
+		pod.SetPullPolicyDefaults(&statefulset.Spec.Template.Spec)
 
 		// Merge containers by name to preserve server-defaulted fields
 		// (e.g. TerminationMessagePath, ImagePullPolicy) and avoid


### PR DESCRIPTION
When `ImagePullPolicy` is not explicitly set on a container and the image tag is "latest" or unset, Kubernetes defaults the policy to `Always`, causing unnecessary image pulls on every pod restart. This affected ~120 container definitions across all service operators.

Add `pod.SetPullPolicyDefaults()` which sets `PullIfNotPresent` on any container that lacks an explicit policy, and call it from the `Deployment`, `DaemonSet`, `StatefulSet`, `Job`, and `CronJob` `CreateOrPatch` paths. Containers that already set an explicit policy (including `PullAlways`) are left unchanged.

Relates-To: https://redhat.atlassian.net/browse/OSPRH-26843

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>