### PR TITLE
probes: Allow optional probe types in CreateProbeSetV2

### DIFF
--- a/modules/common/probes/probes.go
+++ b/modules/common/probes/probes.go
@@ -80,9 +80,9 @@ func CreateProbeSet(
 	return CreateProbeSetV2(overrides, defaults)
 }
 
-// CreateProbeSetV2 creates all probes at once using the interface.
-// Each probe's handler type, port, scheme, path, and command are determined
-// by the ProbeConf fields in the defaults and overrides.
+// CreateProbeSetV2 creates configured probes using defaults and overrides.
+// Each probe is built only when present in defaults or overrides; unset probe
+// types are omitted from the returned ProbeSet.
 func CreateProbeSetV2(
 	overrides ProbeOverrides,
 	defaults OverrideSpec,
@@ -99,32 +99,43 @@ func CreateProbeSetV2(
 		return conf
 	}
 
-	livenessProbe, err := SetProbeConfV2(
-		mergeConf(defaults.LivenessProbes, overrides.GetLivenessProbes()),
-	)
-	if err != nil {
-		return nil, err
+	result := &ProbeSet{}
+
+	if probeConfigured(defaults.LivenessProbes, overrides.GetLivenessProbes()) {
+		livenessProbe, err := SetProbeConfV2(
+			mergeConf(defaults.LivenessProbes, overrides.GetLivenessProbes()),
+		)
+		if err != nil {
+			return nil, err
+		}
+		result.Liveness = livenessProbe
 	}
 
-	readinessProbe, err := SetProbeConfV2(
-		mergeConf(defaults.ReadinessProbes, overrides.GetReadinessProbes()),
-	)
-	if err != nil {
-		return nil, err
+	if probeConfigured(defaults.ReadinessProbes, overrides.GetReadinessProbes()) {
+		readinessProbe, err := SetProbeConfV2(
+			mergeConf(defaults.ReadinessProbes, overrides.GetReadinessProbes()),
+		)
+		if err != nil {
+			return nil, err
+		}
+		result.Readiness = readinessProbe
 	}
 
-	startupProbe, err := SetProbeConfV2(
-		mergeConf(defaults.StartupProbes, overrides.GetStartupProbes()),
-	)
-	if err != nil {
-		return nil, err
+	if probeConfigured(defaults.StartupProbes, overrides.GetStartupProbes()) {
+		startupProbe, err := SetProbeConfV2(
+			mergeConf(defaults.StartupProbes, overrides.GetStartupProbes()),
+		)
+		if err != nil {
+			return nil, err
+		}
+		result.Startup = startupProbe
 	}
 
-	return &ProbeSet{
-		Liveness:  livenessProbe,
-		Readiness: readinessProbe,
-		Startup:   startupProbe,
-	}, nil
+	return result, nil
+}
+
+func probeConfigured(defaults *ProbeConf, override *ProbeConf) bool {
+	return defaults != nil || override != nil
 }
 
 // SetProbeConfV2 configures and returns a probe based on the ProbeConf

--- a/modules/common/probes/probes_test.go
+++ b/modules/common/probes/probes_test.go
@@ -633,6 +633,88 @@ func TestCreateProbeSetV2(t *testing.T) {
 	})
 }
 
+func TestCreateProbeSetV2OptionalProbes(t *testing.T) {
+	scheme := v1.URISchemeHTTP
+	command := []string{"/usr/bin/pgrep", "nova-scheduler"}
+
+	t.Run("liveness and readiness only", func(t *testing.T) {
+		defaults := OverrideSpec{
+			LivenessProbes: &ProbeConf{
+				TimeoutSeconds:      30,
+				PeriodSeconds:       30,
+				InitialDelaySeconds: 5,
+			},
+			ReadinessProbes: &ProbeConf{
+				TimeoutSeconds:      30,
+				PeriodSeconds:       30,
+				InitialDelaySeconds: 5,
+			},
+		}
+
+		probeSet, err := CreateProbeSet(8778, &scheme, OverrideSpec{}, defaults)
+		if err != nil {
+			t.Fatalf("CreateProbeSet() unexpected error: %v", err)
+		}
+		if probeSet.Liveness == nil || probeSet.Readiness == nil {
+			t.Fatal("expected liveness and readiness probes")
+		}
+		if probeSet.Startup != nil {
+			t.Fatal("startup probe should be omitted when not configured")
+		}
+	})
+
+	t.Run("liveness and startup exec only", func(t *testing.T) {
+		defaults := OverrideSpec{
+			LivenessProbes: &ProbeConf{
+				Type:                ProbeHandlerExec,
+				Command:             command,
+				TimeoutSeconds:      10,
+				PeriodSeconds:       20,
+				InitialDelaySeconds: 15,
+			},
+			StartupProbes: &ProbeConf{
+				Type:                ProbeHandlerExec,
+				Command:             command,
+				TimeoutSeconds:      10,
+				PeriodSeconds:       10,
+				InitialDelaySeconds: 20,
+				FailureThreshold:    12,
+			},
+		}
+
+		probeSet, err := CreateProbeSetV2(OverrideSpec{}, defaults)
+		if err != nil {
+			t.Fatalf("CreateProbeSetV2() unexpected error: %v", err)
+		}
+		if probeSet.Liveness == nil || probeSet.Startup == nil {
+			t.Fatal("expected liveness and startup probes")
+		}
+		if probeSet.Readiness != nil {
+			t.Fatal("readiness probe should be omitted when not configured")
+		}
+	})
+
+	t.Run("override only", func(t *testing.T) {
+		overrides := OverrideSpec{
+			LivenessProbes: &ProbeConf{
+				Path: "/healthcheck",
+				Port: 8080,
+			},
+		}
+
+		probeSet, err := CreateProbeSetV2(overrides, OverrideSpec{})
+		if err != nil {
+			t.Fatalf("CreateProbeSetV2() unexpected error: %v", err)
+		}
+		if probeSet.Liveness == nil {
+			t.Fatal("expected liveness probe from override only")
+		}
+		if probeSet.Readiness != nil || probeSet.Startup != nil {
+			t.Fatal("expected only liveness probe")
+		}
+	})
+}
+
 func TestValidateProbeConfExec(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
CreateProbeSetV2 only builds probes present in defaults or overrides. Unconfigured probe types are omitted from the returned ProbeSet instead of being forced through SetProbeConfV2 with empty configuration.