### PR TITLE
Add lib-common helpers for kolla entrypoint removal

### DIFF
--- a/modules/common/pod/security.go
+++ b/modules/common/pod/security.go
@@ -22,17 +22,15 @@ import (
 )
 
 // RestrictiveSecurityContext returns a hardened container SecurityContext
-// suitable for unprivileged workloads. It sets RunAsNonRoot, drops all
-// capabilities, disables privilege escalation, and applies the RuntimeDefault
-// seccomp profile. The provided uid is used for both RunAsUser and RunAsGroup.
+// suitable for unprivileged workloads. It sets RunAsUser to uid, RunAsGroup
+// to gid, RunAsNonRoot, drops all capabilities, disables privilege escalation,
+// and applies the RuntimeDefault seccomp profile.
 // Optional addCapabilities are added back after dropping ALL.
-func RestrictiveSecurityContext(uid int64, addCapabilities ...corev1.Capability) *corev1.SecurityContext {
-	return RestrictiveSecurityContextWithGID(uid, uid, addCapabilities...)
-}
-
-// RestrictiveSecurityContextWithGID is like RestrictiveSecurityContext but
-// allows specifying a different GID.
-func RestrictiveSecurityContextWithGID(uid, gid int64, addCapabilities ...corev1.Capability) *corev1.SecurityContext {
+//
+// Does not set ReadOnlyRootFilesystem -- a future RestrictiveReadOnlySecurityContext
+// is the intended way for an individual service to opt into that later, without
+// changing this function's behavior for every existing caller.
+func RestrictiveSecurityContext(uid, gid int64, addCapabilities ...corev1.Capability) *corev1.SecurityContext {
 	caps := &corev1.Capabilities{
 		Drop: []corev1.Capability{"ALL"},
 	}
@@ -43,11 +41,54 @@ func RestrictiveSecurityContextWithGID(uid, gid int64, addCapabilities ...corev1
 		RunAsUser:                ptr.To(uid),
 		RunAsGroup:               ptr.To(gid),
 		RunAsNonRoot:             ptr.To(true),
-		ReadOnlyRootFilesystem:   ptr.To(true),
 		AllowPrivilegeEscalation: ptr.To(false),
 		Capabilities:             caps,
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},
+	}
+}
+
+// RestrictivePodSecurityContext returns a hardened PodSecurityContext for
+// unprivileged workloads. It sets RunAsUser to uid, RunAsGroup and FSGroup
+// to gid, RunAsNonRoot, and applies the RuntimeDefault seccomp profile.
+// FSGroup ensures that volumes mounted from Secrets/ConfigMaps are
+// group-readable by the service process without needing chown.
+//
+// Optional supplementalGroups grant additional GIDs to the pod — use this
+// when the workload needs to read files not covered by FSGroup, e.g.
+// RPM-shipped configs baked into the container image with restrictive
+// group ownership rather than mounted from a Secret/ConfigMap.
+func RestrictivePodSecurityContext(uid, gid int64, supplementalGroups ...int64) *corev1.PodSecurityContext {
+	return &corev1.PodSecurityContext{
+		RunAsUser:          ptr.To(uid),
+		RunAsGroup:         ptr.To(gid),
+		RunAsNonRoot:       ptr.To(true),
+		FSGroup:            ptr.To(gid),
+		SupplementalGroups: supplementalGroups,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+// RestrictiveSecurityContextWithGID is an alias for RestrictiveSecurityContext.
+// Deprecated: use RestrictiveSecurityContext directly.
+func RestrictiveSecurityContextWithGID(uid, gid int64, addCapabilities ...corev1.Capability) *corev1.SecurityContext {
+	return RestrictiveSecurityContext(uid, gid, addCapabilities...)
+}
+
+// PrivilegedSecurityContext returns a SecurityContext for a workload that
+// needs full Privileged access to the host (e.g. LVM/iSCSI/multipath device
+// management via nsenter'd host binaries) and therefore cannot use
+// RestrictiveSecurityContext — Privileged is incompatible with
+// ReadOnlyRootFilesystem and capability dropping. RunAsUser is set to uid,
+// RunAsGroup to gid.
+func PrivilegedSecurityContext(uid, gid int64) *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		RunAsUser:    ptr.To(uid),
+		RunAsGroup:   ptr.To(gid),
+		RunAsNonRoot: ptr.To(true),
+		Privileged:   ptr.To(true),
 	}
 }

--- a/modules/common/pod/security_test.go
+++ b/modules/common/pod/security_test.go
@@ -24,35 +24,8 @@ import (
 
 func TestRestrictiveSecurityContext(t *testing.T) {
 	var uid int64 = 42457
-	sc := RestrictiveSecurityContext(uid)
-
-	if sc.RunAsUser == nil || *sc.RunAsUser != uid {
-		t.Errorf("expected RunAsUser %d, got %v", uid, sc.RunAsUser)
-	}
-	if sc.RunAsGroup == nil || *sc.RunAsGroup != uid {
-		t.Errorf("expected RunAsGroup %d, got %v", uid, sc.RunAsGroup)
-	}
-	if sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
-		t.Error("expected RunAsNonRoot true")
-	}
-	if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
-		t.Error("expected AllowPrivilegeEscalation false")
-	}
-	if sc.Capabilities == nil || len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != "ALL" {
-		t.Errorf("expected Capabilities.Drop [ALL], got %v", sc.Capabilities)
-	}
-	if sc.SeccompProfile == nil || sc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
-		t.Errorf("expected SeccompProfile RuntimeDefault, got %v", sc.SeccompProfile)
-	}
-	if sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
-		t.Error("expected ReadOnlyRootFilesystem true")
-	}
-}
-
-func TestRestrictiveSecurityContextWithGID(t *testing.T) {
-	var uid int64 = 42415
-	var gid int64 = 42416
-	sc := RestrictiveSecurityContextWithGID(uid, gid)
+	var gid int64 = 42458
+	sc := RestrictiveSecurityContext(uid, gid)
 
 	if sc.RunAsUser == nil || *sc.RunAsUser != uid {
 		t.Errorf("expected RunAsUser %d, got %v", uid, sc.RunAsUser)
@@ -66,17 +39,88 @@ func TestRestrictiveSecurityContextWithGID(t *testing.T) {
 	if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
 		t.Error("expected AllowPrivilegeEscalation false")
 	}
+	if sc.Capabilities == nil || len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != "ALL" {
+		t.Errorf("expected Capabilities.Drop [ALL], got %v", sc.Capabilities)
+	}
+	if sc.SeccompProfile == nil || sc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Errorf("expected SeccompProfile RuntimeDefault, got %v", sc.SeccompProfile)
+	}
+	if sc.ReadOnlyRootFilesystem != nil {
+		t.Errorf("expected ReadOnlyRootFilesystem unset, got %v", sc.ReadOnlyRootFilesystem)
+	}
+}
+
+func TestRestrictivePodSecurityContext(t *testing.T) {
+	var uid int64 = 42425
+	var gid int64 = 42426
+	psc := RestrictivePodSecurityContext(uid, gid)
+
+	if psc.RunAsUser == nil || *psc.RunAsUser != uid {
+		t.Errorf("expected RunAsUser %d, got %v", uid, psc.RunAsUser)
+	}
+	if psc.RunAsGroup == nil || *psc.RunAsGroup != gid {
+		t.Errorf("expected RunAsGroup %d, got %v", gid, psc.RunAsGroup)
+	}
+	if psc.RunAsNonRoot == nil || !*psc.RunAsNonRoot {
+		t.Error("expected RunAsNonRoot true")
+	}
+	if psc.FSGroup == nil || *psc.FSGroup != gid {
+		t.Errorf("expected FSGroup %d, got %v", gid, psc.FSGroup)
+	}
+	if psc.SeccompProfile == nil || psc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Errorf("expected SeccompProfile RuntimeDefault, got %v", psc.SeccompProfile)
+	}
+}
+
+func TestRestrictivePodSecurityContextNoSupplementalGroups(t *testing.T) {
+	psc := RestrictivePodSecurityContext(42425, 42425)
+	if psc.SupplementalGroups != nil {
+		t.Errorf("expected no SupplementalGroups, got %v", psc.SupplementalGroups)
+	}
+}
+
+func TestRestrictivePodSecurityContextWithSupplementalGroups(t *testing.T) {
+	psc := RestrictivePodSecurityContext(42425, 42425, 48)
+
+	if len(psc.SupplementalGroups) != 1 || psc.SupplementalGroups[0] != 48 {
+		t.Errorf("expected SupplementalGroups [48], got %v", psc.SupplementalGroups)
+	}
+}
+
+func TestPrivilegedSecurityContext(t *testing.T) {
+	var uid int64 = 42407
+	var gid int64 = 42408
+	sc := PrivilegedSecurityContext(uid, gid)
+
+	if sc.RunAsUser == nil || *sc.RunAsUser != uid {
+		t.Errorf("expected RunAsUser %d, got %v", uid, sc.RunAsUser)
+	}
+	if sc.RunAsGroup == nil || *sc.RunAsGroup != gid {
+		t.Errorf("expected RunAsGroup %d, got %v", gid, sc.RunAsGroup)
+	}
+	if sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
+		t.Error("expected RunAsNonRoot true")
+	}
+	if sc.Privileged == nil || !*sc.Privileged {
+		t.Error("expected Privileged true")
+	}
+	if sc.Capabilities != nil {
+		t.Errorf("expected no Capabilities set, got %v", sc.Capabilities)
+	}
+	if sc.ReadOnlyRootFilesystem != nil {
+		t.Errorf("expected ReadOnlyRootFilesystem unset, got %v", sc.ReadOnlyRootFilesystem)
+	}
 }
 
 func TestRestrictiveSecurityContextNoAddCaps(t *testing.T) {
-	sc := RestrictiveSecurityContext(42457)
+	sc := RestrictiveSecurityContext(42457, 42457)
 	if sc.Capabilities.Add != nil {
 		t.Errorf("expected no Add capabilities, got %v", sc.Capabilities.Add)
 	}
 }
 
 func TestRestrictiveSecurityContextWithAddCaps(t *testing.T) {
-	sc := RestrictiveSecurityContext(42457, "NET_BIND_SERVICE", "CHOWN")
+	sc := RestrictiveSecurityContext(42457, 42457, "NET_BIND_SERVICE", "CHOWN")
 
 	if len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != "ALL" {
 		t.Errorf("expected Drop [ALL], got %v", sc.Capabilities.Drop)

--- a/modules/common/util/templates/common/config/ssl.conf
+++ b/modules/common/util/templates/common/config/ssl.conf
@@ -8,7 +8,7 @@
   AddType application/x-pkcs7-crl    .crl
 
   SSLPassPhraseDialog builtin
-  SSLSessionCache "shmcb:/var/cache/mod_ssl/scache(512000)"
+  SSLSessionCache "shmcb:/run/httpd/ssl_scache(512000)"
   SSLSessionCacheTimeout 300
   Mutex default
   SSLCryptoDevice builtin

--- a/modules/common/volume/volume.go
+++ b/modules/common/volume/volume.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	// RunHttpdVolumeName is the standard volume name for the httpd PID file directory.
+	RunHttpdVolumeName = "run-httpd"
+	// RunHttpdMountPath is the canonical mount path for the httpd PID directory.
+	RunHttpdMountPath = "/run/httpd"
+	// VarLogHttpdVolumeName is the standard volume name for the httpd log directory.
+	VarLogHttpdVolumeName = "var-log-httpd"
+	// VarLogHttpdMountPath is the mount path for the httpd log directory.
+	VarLogHttpdMountPath = "/var/log/httpd"
+	// TmpVolumeName is the standard volume name for /tmp.
+	TmpVolumeName = "tmp"
+	// TmpMountPath is the mount path for /tmp.
+	TmpMountPath = "/tmp"
+	// HomeDirCacheSubdir is the ".cache" subdirectory under a service's
+	// home directory. RHEL's python3-setuptools downstream patch caches
+	// iter_entry_points() scans under $HOME/.cache/python-entrypoints/
+	// on every process start. Needs a writable emptyDir mount when
+	// ReadOnlyRootFilesystem is enabled.
+	HomeDirCacheSubdir = ".cache"
+)
+
+var configSecretMode int32 = 0440
+
+// WritableDirVolume returns an emptyDir Volume. Used for any path that needs
+// to be writable by a non-root service user: /run/httpd (PID file),
+// /var/log/httpd, /var/log/<service>, /tmp, service home-dir subdirs, etc.
+// Pass an optional sizeLimit to cap the volume's ephemeral storage.
+func WritableDirVolume(name string, sizeLimit ...*resource.Quantity) corev1.Volume {
+	var limit *resource.Quantity
+	if len(sizeLimit) > 0 {
+		limit = sizeLimit[0]
+	}
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{SizeLimit: limit},
+		},
+	}
+}
+
+// WritableDirVolumeMount returns a VolumeMount for a writable emptyDir.
+func WritableDirVolumeMount(name, mountPath string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      name,
+		MountPath: mountPath,
+	}
+}
+
+// WritableDirSubPathMounts returns SubPath VolumeMounts onto the emptyDir
+// named volumeName for the given subdirectories of baseDir. Mounted via
+// SubPath rather than shadowing baseDir itself, since the image may bake
+// real content there (e.g. shell dotfiles under a service home directory).
+func WritableDirSubPathMounts(volumeName, baseDir string, subdirs ...string) []corev1.VolumeMount {
+	mounts := make([]corev1.VolumeMount, 0, len(subdirs))
+	for _, subdir := range subdirs {
+		mounts = append(mounts, corev1.VolumeMount{
+			Name:      volumeName,
+			MountPath: baseDir + "/" + subdir,
+			SubPath:   subdir,
+		})
+	}
+	return mounts
+}
+
+// ConfigSecretVolumes returns Volumes and VolumeMounts for a list of Secret
+// names, each mounted read-only at /var/lib/config-data/secret-{idx} with
+// DefaultMode 0440.
+func ConfigSecretVolumes(secretNames []string) ([]corev1.Volume, []corev1.VolumeMount) {
+	volumes := make([]corev1.Volume, 0, len(secretNames))
+	mounts := make([]corev1.VolumeMount, 0, len(secretNames))
+
+	for idx, secretName := range secretNames {
+		volumes = append(volumes, corev1.Volume{
+			Name: secretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  secretName,
+					DefaultMode: &configSecretMode,
+				},
+			},
+		})
+		mounts = append(mounts, corev1.VolumeMount{
+			Name:      secretName,
+			MountPath: "/var/lib/config-data/secret-" + strconv.Itoa(idx),
+			ReadOnly:  true,
+		})
+	}
+
+	return volumes, mounts
+}

--- a/modules/common/volume/volume_test.go
+++ b/modules/common/volume/volume_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestWritableDirVolumeNoSizeLimit(t *testing.T) {
+	v := WritableDirVolume("run-httpd")
+	if v.Name != "run-httpd" {
+		t.Errorf("expected Name %q, got %q", "run-httpd", v.Name)
+	}
+	if v.EmptyDir == nil {
+		t.Fatal("expected EmptyDir to be set")
+	}
+	if v.EmptyDir.SizeLimit != nil {
+		t.Errorf("expected no SizeLimit, got %v", v.EmptyDir.SizeLimit)
+	}
+}
+
+func TestWritableDirVolumeWithSizeLimit(t *testing.T) {
+	limit := resource.MustParse("64Mi")
+	v := WritableDirVolume("home", &limit)
+	if v.EmptyDir == nil || v.EmptyDir.SizeLimit == nil {
+		t.Fatal("expected SizeLimit to be set")
+	}
+	if v.EmptyDir.SizeLimit.String() != "64Mi" {
+		t.Errorf("expected SizeLimit 64Mi, got %v", v.EmptyDir.SizeLimit)
+	}
+}
+
+func TestWritableDirVolumeMount(t *testing.T) {
+	m := WritableDirVolumeMount("run-httpd", "/run/httpd")
+	if m.Name != "run-httpd" {
+		t.Errorf("expected Name %q, got %q", "run-httpd", m.Name)
+	}
+	if m.MountPath != "/run/httpd" {
+		t.Errorf("expected MountPath %q, got %q", "/run/httpd", m.MountPath)
+	}
+}
+
+func TestWritableDirSubPathMounts(t *testing.T) {
+	mounts := WritableDirSubPathMounts("home", "/var/lib/service", "tmp", ".cache")
+	if len(mounts) != 2 {
+		t.Fatalf("expected 2 mounts, got %d", len(mounts))
+	}
+	if mounts[0].MountPath != "/var/lib/service/tmp" || mounts[0].SubPath != "tmp" {
+		t.Errorf("unexpected first mount: %+v", mounts[0])
+	}
+	if mounts[1].MountPath != "/var/lib/service/.cache" || mounts[1].SubPath != ".cache" {
+		t.Errorf("unexpected second mount: %+v", mounts[1])
+	}
+}
+
+func TestWritableDirSubPathMountsNoSubdirs(t *testing.T) {
+	mounts := WritableDirSubPathMounts("home", "/var/lib/service")
+	if len(mounts) != 0 {
+		t.Errorf("expected no mounts, got %v", mounts)
+	}
+}
+
+func TestConfigSecretVolumes(t *testing.T) {
+	vols, mounts := ConfigSecretVolumes([]string{"secret-a", "secret-b"})
+	if len(vols) != 2 || len(mounts) != 2 {
+		t.Fatalf("expected 2 volumes and 2 mounts, got %d and %d", len(vols), len(mounts))
+	}
+	if vols[0].Secret == nil || vols[0].Secret.SecretName != "secret-a" {
+		t.Errorf("expected SecretName %q", "secret-a")
+	}
+	if vols[0].Secret.DefaultMode == nil || *vols[0].Secret.DefaultMode != 0440 {
+		t.Errorf("expected DefaultMode 0440, got %v", vols[0].Secret.DefaultMode)
+	}
+	if mounts[0].MountPath != "/var/lib/config-data/secret-0" {
+		t.Errorf("expected MountPath %q, got %q", "/var/lib/config-data/secret-0", mounts[0].MountPath)
+	}
+	if !mounts[0].ReadOnly {
+		t.Error("expected ReadOnly to be true")
+	}
+}
+
+func TestConfigSecretVolumesEmpty(t *testing.T) {
+	vols, mounts := ConfigSecretVolumes(nil)
+	if len(vols) != 0 || len(mounts) != 0 {
+		t.Errorf("expected empty results, got %d volumes, %d mounts", len(vols), len(mounts))
+	}
+}
+
+func TestConstants(t *testing.T) {
+	tests := []struct {
+		name, volume, path string
+	}{
+		{"RunHttpd", RunHttpdVolumeName, RunHttpdMountPath},
+		{"VarLogHttpd", VarLogHttpdVolumeName, VarLogHttpdMountPath},
+		{"Tmp", TmpVolumeName, TmpMountPath},
+	}
+	for _, tt := range tests {
+		v := WritableDirVolume(tt.volume)
+		m := WritableDirVolumeMount(tt.volume, tt.path)
+		if v.Name != tt.volume {
+			t.Errorf("%s: volume Name = %q, want %q", tt.name, v.Name, tt.volume)
+		}
+		if m.MountPath != tt.path {
+			t.Errorf("%s: mount Path = %q, want %q", tt.name, m.MountPath, tt.path)
+		}
+	}
+}


### PR DESCRIPTION
Shared building blocks for the kolla entrypoint removal across all service operators. Every operator currently copy-pastes the same SecurityContext construction, emptyDir volume definitions, and writable-path mounts — this PR consolidates them into lib-common so operators can adopt the non-root, non-kolla pod spec with minimal per-repo code.

- SecurityContext helpers (modules/common/pod/security.go): RestrictiveSecurityContext now takes an explicit gid parameter (breaking change from the single-uid signature), adds RestrictivePodSecurityContext for pod-level hardening with FSGroup and optional supplemental groups, and PrivilegedSecurityContext for workloads that need full host device access (Ceph RBD via os-brick). Removes ReadOnlyRootFilesystem from the default — a future opt-in variant will handle that without changing behavior for existing callers. Deprecates RestrictiveSecurityContextWithGID.
- Volume helpers (modules/common/volume/): New package with WritableDirVolume/WritableDirVolumeMount for generic emptyDir paths, WritableDirSubPathMounts for writable subdirectories under a base path (e.g. service home dir .cache), and ConfigSecretVolumes for config Secrets at /var/lib/config-data/secret-{idx}. Well-known constants for standardized volume names and mount paths (RunHttpd, VarLogHttpd, Tmp, HomeDirCacheSubdir).
- ssl.conf fix: Moves SSLSessionCache from /var/cache/mod_ssl/scache (doesn't exist in the container image and is unwritable by non-root) to /run/httpd/ssl_scache, matching the existing SSLStaplingCache path and the writable emptyDir every operator already mounts.