### PR TITLE
object: add PruneSecretConsumerFinalizers self-heal helper

### DIFF
--- a/modules/common/object/metadata.go
+++ b/modules/common/object/metadata.go
@@ -232,6 +232,65 @@ func RemoveSecretConsumerFinalizer(
 	return RemoveConsumerFinalizer(ctx, h, secret, consumerFinalizer)
 }
 
+// PruneSecretConsumerFinalizers removes consumerFinalizer from every secret in
+// namespace that still carries it and is not named in keep. Empty names in keep
+// are ignored.
+//
+// It self-heals finalizers stranded on superseded secrets: during rapid rotation
+// (e.g. secret A -> B -> C before the workload becomes ready), the consumer
+// finalizer can be added to an intermediate secret B that the workload never
+// applies. FinalizeSecretRotation only ever releases the single tracked "old"
+// secret, so B's finalizer would otherwise leak and block deletion of its Secret
+// and revocation of the associated backend credential. Callers pass the set of
+// secrets that legitimately hold the finalizer (the applied and current secrets
+// for every rotating input guarded by the same finalizer) as keep, and any other
+// secret carrying it is pruned.
+//
+// The secrets are read through the caller's (cached) client; the prune is
+// idempotent and safe to call every reconcile.
+//
+// keep must enumerate every secret in the namespace that legitimately holds
+// consumerFinalizer: the prune removes it from all others. This assumes a single
+// consumer of consumerFinalizer per namespace (the CR is a namespace singleton,
+// as is the norm for OpenStackControlPlane-managed services). If multiple CR
+// instances sharing the same consumerFinalizer coexist in one namespace, each
+// only knows its own keep set and would prune the others' finalizers; use a
+// per-instance finalizer in that case.
+func PruneSecretConsumerFinalizers(
+	ctx context.Context,
+	h *helper.Helper,
+	namespace string,
+	consumerFinalizer string,
+	keep ...string,
+) error {
+	keepSet := make(map[string]struct{}, len(keep))
+	for _, name := range keep {
+		if name != "" {
+			keepSet[name] = struct{}{}
+		}
+	}
+
+	secretList := &corev1.SecretList{}
+	if err := h.GetClient().List(ctx, secretList, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list secrets in namespace %s: %w", namespace, err)
+	}
+
+	for i := range secretList.Items {
+		secret := &secretList.Items[i]
+		if _, ok := keepSet[secret.Name]; ok {
+			continue
+		}
+		if !controllerutil.ContainsFinalizer(secret, consumerFinalizer) {
+			continue
+		}
+		if err := RemoveConsumerFinalizer(ctx, h, secret, consumerFinalizer); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // FinalizeSecretRotation handles the rotation guard for a credential secret
 // (transport URL, application credential, or any other rotating secret).
 // It detects whether rotation is in progress and:

--- a/modules/common/object/metadata_test.go
+++ b/modules/common/object/metadata_test.go
@@ -242,6 +242,100 @@ func TestFinalizeSecretRotation(t *testing.T) {
 	})
 }
 
+func TestPruneSecretConsumerFinalizers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	const (
+		namespace = "openstack"
+		finalizer = "openstack.org/test-consumer"
+	)
+
+	secretWithFinalizer := func(name string) *corev1.Secret {
+		s := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		}
+		controllerutil.AddFinalizer(s, finalizer)
+		return s
+	}
+	hasFinalizer := func(g Gomega, h *helper.Helper, name string) bool {
+		s := &corev1.Secret{}
+		g.Expect(h.GetClient().Get(ctx, types.NamespacedName{
+			Name: name, Namespace: namespace,
+		}, s)).To(Succeed())
+		return controllerutil.ContainsFinalizer(s, finalizer)
+	}
+
+	t.Run("prunes superseded intermediate secret, keeps applied and current", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// rotation A -> B -> C before readiness: A is applied, C is current,
+		// B is a stranded intermediate that must have its finalizer pruned.
+		h, err := setupHelper(
+			secretWithFinalizer("secret-a"),
+			secretWithFinalizer("secret-b"),
+			secretWithFinalizer("secret-c"),
+		)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(PruneSecretConsumerFinalizers(
+			ctx, h, namespace, finalizer, "secret-a", "secret-c",
+		)).To(Succeed())
+
+		g.Expect(hasFinalizer(g, h, "secret-a")).To(BeTrue())
+		g.Expect(hasFinalizer(g, h, "secret-b")).To(BeFalse())
+		g.Expect(hasFinalizer(g, h, "secret-c")).To(BeTrue())
+	})
+
+	t.Run("ignores empty names in keep", func(t *testing.T) {
+		g := NewWithT(t)
+
+		h, err := setupHelper(secretWithFinalizer("secret-a"))
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(PruneSecretConsumerFinalizers(
+			ctx, h, namespace, finalizer, "", "secret-a", "",
+		)).To(Succeed())
+
+		g.Expect(hasFinalizer(g, h, "secret-a")).To(BeTrue())
+	})
+
+	t.Run("leaves secrets without the finalizer untouched", func(t *testing.T) {
+		g := NewWithT(t)
+
+		plain := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "plain", Namespace: namespace},
+		}
+		h, err := setupHelper(plain, secretWithFinalizer("stale"))
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(PruneSecretConsumerFinalizers(
+			ctx, h, namespace, finalizer, "current",
+		)).To(Succeed())
+
+		g.Expect(hasFinalizer(g, h, "plain")).To(BeFalse())
+		g.Expect(hasFinalizer(g, h, "stale")).To(BeFalse())
+	})
+
+	t.Run("List fails", func(t *testing.T) {
+		g := NewWithT(t)
+
+		h, err := setupHelperWithInterceptor(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*corev1.SecretList); ok {
+					return errSyntheticAPI
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}, secretWithFinalizer("secret-a"))
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(PruneSecretConsumerFinalizers(
+			ctx, h, namespace, finalizer, "secret-a",
+		)).To(HaveOccurred())
+	})
+}
+
 func TestManageRotationGracePeriod(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
FinalizeSecretRotation only ever releases the single tracked "old" secret. During rapid rotation (A -> B -> C before the workload becomes ready) the consumer finalizer can be added to an intermediate secret the workload never applies, and that finalizer then leaks: it blocks deletion of the Secret and revocation of the associated backend credential.

Add PruneSecretConsumerFinalizers, which removes a consumer finalizer from every secret in a namespace except those the caller enumerates as legitimately holding it (keep). It is idempotent and safe to call every reconcile. Assumes a single consumer of the finalizer per namespace, which holds for OpenStackControlPlane-managed service singletons.