### PR TITLE
Add Aetos UID and GID to registry

### DIFF
--- a/modules/users/registry.go
+++ b/modules/users/registry.go
@@ -37,6 +37,8 @@ type ServiceUser struct {
 // UIDs on PersistentVolumes. Changing a UID would require a manual chown
 // migration on every PV in every deployment.
 const (
+	AetosUID           int64 = 42404
+	AetosGID           int64 = 42404
 	AnsibleUID         int64 = 227
 	AnsibleGID         int64 = 227
 	AodhUID            int64 = 42402


### PR DESCRIPTION
Add the 42404 as Aetos UID/GID to the user registry. Same as https://github.com/openstack-k8s-operators/s2i-openstack-containers/blob/main/containers/base/scripts/uid_gid_manage#L36C34-L36C39