### PR TITLE
certmanager: algorithm-aware default certificate key usages

### DIFF
--- a/modules/certmanager/certificate.go
+++ b/modules/certmanager/certificate.go
@@ -62,7 +62,38 @@ type CertificateRequest struct {
 	Annotations map[string]string
 	Labels      map[string]string
 	Usages      []certmgrv1.KeyUsage
-	Subject     *certmgrv1.X509Subject
+	// PrivateKey configures the certificate private key (algorithm, size,
+	// encoding, rotation policy). When nil, cert-manager applies its own defaults
+	// (currently RSA-2048). The private key algorithm also drives the default key
+	// usages (see defaultUsages) when Usages is not set; explicitly provided
+	// Usages are used as-is. See OSPRH-27774 / OSPRH-27806.
+	PrivateKey *certmgrv1.CertificatePrivateKey
+	Subject    *certmgrv1.X509Subject
+}
+
+// defaultUsages returns the default key usages for the given private key
+// algorithm. It is only applied when the caller does not provide Usages;
+// explicitly requested usages are always honored as-is.
+//
+// keyEncipherment is only valid for RSA keys: it is required solely by legacy
+// static RSA key-transport TLS cipher suites (OpenSSL kRSA / TLS_RSA_WITH_*).
+// ECDSA/Ed25519 do not use it and PQC algorithms such as ML-DSA do not support
+// it. An empty algorithm is treated as RSA, matching cert-manager's default, so
+// existing RSA callers keep keyEncipherment and see no certificate change.
+func defaultUsages(algorithm certmgrv1.PrivateKeyAlgorithm) []certmgrv1.KeyUsage {
+	// cert-manager defaults to RSA when no algorithm is set.
+	if algorithm == "" || algorithm == certmgrv1.RSAKeyAlgorithm {
+		return []certmgrv1.KeyUsage{
+			certmgrv1.UsageKeyEncipherment,
+			certmgrv1.UsageDigitalSignature,
+			certmgrv1.UsageServerAuth,
+		}
+	}
+
+	return []certmgrv1.KeyUsage{
+		certmgrv1.UsageDigitalSignature,
+		certmgrv1.UsageServerAuth,
+	}
 }
 
 // NewCertificate returns an initialized Certificate.
@@ -191,13 +222,15 @@ func EnsureCert(
 		request.Duration = ptr.To(time.Hour * 24 * 365)
 	}
 
-	// default to serverAuth
+	// Default the key usages based on the private key algorithm when the caller
+	// does not provide them (RSA keeps keyEncipherment, non-RSA/PQC omit it).
+	// Explicitly requested usages are used as-is. See OSPRH-27774.
 	if request.Usages == nil {
-		request.Usages = []certmgrv1.KeyUsage{
-			certmgrv1.UsageKeyEncipherment,
-			certmgrv1.UsageDigitalSignature,
-			certmgrv1.UsageServerAuth,
+		var algorithm certmgrv1.PrivateKeyAlgorithm
+		if request.PrivateKey != nil {
+			algorithm = request.PrivateKey.Algorithm
 		}
+		request.Usages = defaultUsages(algorithm)
 	}
 
 	// Default cert secrets to restore=false. Service certs are reissued by
@@ -256,6 +289,10 @@ func EnsureCert(
 
 	if request.CommonName != nil {
 		certSpec.CommonName = *request.CommonName
+	}
+
+	if request.PrivateKey != nil {
+		certSpec.PrivateKey = request.PrivateKey
 	}
 
 	certReq := Cert(

--- a/modules/certmanager/certificate_test.go
+++ b/modules/certmanager/certificate_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certmanager
+
+import (
+	"testing"
+
+	certmgrv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	. "github.com/onsi/gomega"
+)
+
+// TestDefaultUsages verifies that the default certificate key usages are
+// algorithm-aware: RSA and the empty (cert-manager default) algorithm include
+// keyEncipherment, while ECDSA and Ed25519 omit it.
+func TestDefaultUsages(t *testing.T) {
+	rsaUsages := []certmgrv1.KeyUsage{
+		certmgrv1.UsageKeyEncipherment,
+		certmgrv1.UsageDigitalSignature,
+		certmgrv1.UsageServerAuth,
+	}
+	nonRSAUsages := []certmgrv1.KeyUsage{
+		certmgrv1.UsageDigitalSignature,
+		certmgrv1.UsageServerAuth,
+	}
+
+	tests := []struct {
+		name      string
+		algorithm certmgrv1.PrivateKeyAlgorithm
+		want      []certmgrv1.KeyUsage
+	}{
+		{
+			name:      "empty algorithm defaults to RSA and includes keyEncipherment",
+			algorithm: "",
+			want:      rsaUsages,
+		},
+		{
+			name:      "RSA includes keyEncipherment",
+			algorithm: certmgrv1.RSAKeyAlgorithm,
+			want:      rsaUsages,
+		},
+		{
+			name:      "ECDSA omits keyEncipherment",
+			algorithm: certmgrv1.ECDSAKeyAlgorithm,
+			want:      nonRSAUsages,
+		},
+		{
+			name:      "Ed25519 omits keyEncipherment",
+			algorithm: certmgrv1.Ed25519KeyAlgorithm,
+			want:      nonRSAUsages,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(defaultUsages(tt.algorithm)).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
The keyEncipherment X.509 key usage is only valid for RSA keys: it is required solely by legacy static RSA key-transport TLS cipher suites (OpenSSL kRSA / TLS_RSA_WITH_*). ECDSA/Ed25519 do not use it and post-quantum algorithms such as ML-DSA do not support it (it makes the certificate invalid).
    
Make the default key usages depend on the requested private key algorithm, applied only when the caller does not provide Usages explicitly:
- RSA (and the empty/default algorithm): keyEncipherment, digitalSignature, serverAuth. Existing RSA callers are unchanged -> no certificate reissue on upgrade.
- non-RSA (ECDSA/Ed25519, and future PQC keys such as ML-DSA): digitalSignature, serverAuth (no keyEncipherment).
    
Usages passed explicitly by the caller are always honored as-is; lib-common does not add or strip keyEncipherment behind the caller's back. Callers that want to move a service off RSA are expected to set both the private key and, where they specify usages explicitly, an appropriate usage list. This lets operators decide the policy (e.g. non-RSA for greenfield, keep RSA for existing environments) and extend it as a PQC migration mechanism lands.
    
Add a CertificateRequest.PrivateKey *certmgrv1.CertificatePrivateKey field, passed through to the Certificate spec's privateKey (algorithm, size, encoding, rotation policy) when set. The private key algorithm also drives the default key usages above. When nil, cert-manager keeps its own defaults, so existing certificates are unchanged.
    
Note: this adds the private key field and the algorithm-aware usages only; changing the default algorithm off cert-manager's RSA-2048 (e.g. to ECDSA P-384) is a deliberate, churn-causing behaviour change tracked separately in OSPRH-27806. cert-manager v1.18.x only supports RSA/ECDSA/Ed25519; end-to-end PQC (ML-DSA) additionally requires cert-manager PQC support and a CA migration path.
    
Jira: OSPRH-27774
Jira: OSPRH-27806